### PR TITLE
Add `turbolinks:before-render` event

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -120,6 +120,9 @@ class Turbolinks.Controller
   viewInvalidated: ->
     @adapter.pageInvalidated()
 
+  viewWillRender: (newBody) ->
+    @notifyApplicationBeforeRender(newBody)
+
   viewRendered: ->
     @lastRenderedLocation = @currentVisit.location
     @notifyApplicationAfterRender()
@@ -153,6 +156,9 @@ class Turbolinks.Controller
 
   notifyApplicationBeforeCachingSnapshot: ->
     @dispatchEvent("turbolinks:before-cache")
+
+  notifyApplicationBeforeRender: (newBody) ->
+    @dispatchEvent("turbolinks:before-render", data: {newBody})
 
   notifyApplicationAfterRender: ->
     @dispatchEvent("turbolinks:render")

--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -41,6 +41,8 @@ class Turbolinks.View
       document.head.appendChild(element.cloneNode(true))
 
     newBody = newSnapshot.body.cloneNode(true)
+    @delegate.viewWillRender(newBody)
+
     importPermanentElementsIntoBody(newBody)
     importRecyclableElementsIntoBody(newBody)
     document.body = newBody

--- a/test/src/fixtures/rendering.html
+++ b/test/src/fixtures/rendering.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Turbolinks</title>
+    <script src="/turbolinks.js"></script>
+  </head>
+  <body>
+    <section>
+      <h1>Rendering</h1>
+      <p><a id="same-origin-link" href="/fixtures/one.html">Same-origin link</a></p>
+    </section>
+  </body>
+</html>

--- a/test/src/modules/rendering_tests.coffee
+++ b/test/src/modules/rendering_tests.coffee
@@ -1,0 +1,21 @@
+QUnit.module "Rendering"
+
+renderingTest = (name, callback) ->
+  sessionTest name, (assert, session, done) ->
+    session.goToLocation "/fixtures/rendering.html", (navigation) ->
+      callback(assert, session, done)
+
+renderingTest "before-render and render events", (assert, session, done) ->
+  session.clickSelector("#same-origin-link")
+  session.waitForEvent "turbolinks:before-render", (event) ->
+    {newBody} = event.data
+    assert.notEqual(session.element.document.body, newBody)
+
+    h1 = newBody.querySelector("h1")
+    assert.equal(h1.textContent, "One")
+
+    session.waitForEvent "turbolinks:render", (event) ->
+      assert.equal(session.element.document.body, newBody)
+
+      session.waitForEvent "turbolinks:load", ->
+        done()


### PR DESCRIPTION
The `turbolinks:before-render` event fires just after Turbolinks creates the new body element but before it imports permanent elements. The new body is exposed as `event.data.newBody`.

This gives the application and third-party libraries a chance to query or manipulate the current and new body elements just before the new body is installed.