### PR TITLE
Add option to skip cache version in links

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -87,10 +87,14 @@ class Turbolinks.Controller
   getCachedSnapshotForLocation: (location) ->
     @cache.get(location)
 
+  shouldCacheSnapshot: ->
+    @getSetting("cache-control") isnt "no-cache"
+
   cacheSnapshot: ->
-    @notifyApplicationBeforeCachingSnapshot()
-    snapshot = @view.getSnapshot()
-    @cache.put(@lastRenderedLocation, snapshot)
+    if @shouldCacheSnapshot()
+      @notifyApplicationBeforeCachingSnapshot()
+      snapshot = @view.getSnapshot()
+      @cache.put(@lastRenderedLocation, snapshot)
 
   # Scrolling
 

--- a/src/turbolinks/snapshot.coffee
+++ b/src/turbolinks/snapshot.coffee
@@ -35,6 +35,9 @@ class Turbolinks.Snapshot
   getTemporaryHeadElements: ->
     @getTemporaryHeadElementSet().getElements()
 
+  isPreviewable: ->
+    @getCacheControlValue() isnt "no-preview"
+
   # Private
 
   getTrackedHeadElementSet: ->
@@ -55,3 +58,6 @@ class Turbolinks.Snapshot
   getHeadElementSet: ->
     @headElementSet ?= new Turbolinks.ElementSet @head.childNodes
 
+  getCacheControlValue: ->
+    [..., element] = @head.querySelectorAll("meta[name='turbolinks-cache-control']")
+    element?.getAttribute("content")

--- a/src/turbolinks/visit.coffee
+++ b/src/turbolinks/visit.coffee
@@ -46,9 +46,10 @@ class Turbolinks.Visit
       @request.send()
 
   getCachedSnapshot: ->
-    snapshot = @controller.getCachedSnapshotForLocation(@location)
-    return if @location.anchor? and not snapshot?.hasAnchor(@location.anchor)
-    snapshot
+    if snapshot = @controller.getCachedSnapshotForLocation(@location)
+      if not @location.anchor? or snapshot.hasAnchor(@location.anchor)
+        if @action is "restore" or snapshot.isPreviewable()
+          snapshot
 
   hasCachedSnapshot: ->
     @getCachedSnapshot()?


### PR DESCRIPTION
The motivation of this PR is to explore a way to fix #7.

Upgrading an application to use this new version of Turbolinks, we found a few situations where loading the cached version when visiting a new page is not working fine. In our case, we would like to skip loading the cached version in two cases:

- We don't want to show data entered by users when visiting again a page with a form
- We also have permalinks to sections where a modal dialog is opened. The animation triggers twice in those cases.

I couldn't find in the API any way to deal with this cases. I'm aware that taking advantage of the `turbolinks:before-cache` event could be used to solve the form issue, e.g. clearing the form at this point. However, I didn't know how to fix the animation problem without adding this option.
Even for the form case, I feel like having a way to skip the cached version would be a much simpler solution.

In case of adding this option, the name of the data attribute can be further discussed.

What do you think about this addition?