### PR TITLE
Revised visit events

### DIFF
--- a/test/src/modules/visit_tests.coffee
+++ b/test/src/modules/visit_tests.coffee
@@ -7,16 +7,21 @@ visitTest = (name, callback) ->
 
 visitTest "programmatically visiting a same-origin location", (assert, session, done) ->
   session.evaluate("Turbolinks.visit('/fixtures/one.html')")
+  eventLocations = {}
+  session.waitForEvent "turbolinks:before-visit", (event) ->
+    eventLocations.beforeVisit = event.data.url
   session.waitForEvent "turbolinks:visit", (event) ->
-    session.waitForNavigation (navigation) ->
-      assert.equal(event.data.url, navigation.location.toString())
-      assert.equal(navigation.location.pathname, "/fixtures/one.html")
-      assert.equal(navigation.action, "push")
-      done()
+    eventLocations.visit = event.data.url
+  session.waitForNavigation (navigation) ->
+    assert.equal(eventLocations.beforeVisit, navigation.location)
+    assert.equal(eventLocations.visit, navigation.location)
+    assert.equal(navigation.location.pathname, "/fixtures/one.html")
+    assert.equal(navigation.action, "push")
+    done()
 
 visitTest "programmatically visiting a cross-origin location falls back to window.location", (assert, session, done) ->
   session.evaluate("Turbolinks.visit('about:blank')")
-  session.waitForEvent "turbolinks:visit", (event) ->
+  session.waitForEvent "turbolinks:before-visit", (event) ->
     session.waitForNavigation (navigation) ->
       assert.equal(event.data.url, "about:blank")
       assert.equal(navigation.location, "about:blank")
@@ -25,8 +30,20 @@ visitTest "programmatically visiting a cross-origin location falls back to windo
 
 visitTest "canceling a visit event prevents navigation", (assert, session, done) ->
   session.clickSelector("#same-origin-link")
-  session.waitForEvent "turbolinks:visit", (event) ->
+  session.waitForEvent "turbolinks:before-visit", (event) ->
     event.preventDefault()
     session.wait ->
       assert.equal(session.element.location.pathname, "/fixtures/visit.html")
+      done()
+
+visitTest "navigation by history is not cancelable", (assert, session, done) ->
+  session.clickSelector "#same-origin-link", ->
+    eventLocations = {}
+    session.waitForEvent "turbolinks:before-visit", (event) ->
+      eventLocations.beforeVisit = event.data.url
+    session.waitForEvent "turbolinks:visit", (event) ->
+      eventLocations.visit = event.data.url
+    session.goBack (navigation) ->
+      assert.notOk(eventLocations.beforeVisit)
+      assert.equal(eventLocations.visit, navigation.location)
       done()


### PR DESCRIPTION
* Renames the cancelable `turbolinks:visit` event to `turbolinks:before-visit`.
* Adds an uncancelable `turbolinks:visit` event, fired immediately after any visit starts.