### PR TITLE
Use Element.set/removeAttribute() for IE10 compat. Fixes #21

### DIFF
--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -19,9 +19,9 @@ class Turbolinks.View
 
   markAsPreview: (isPreview) ->
     if isPreview
-      @element.dataset.turbolinksPreview = ""
+      @element.setAttribute("data-turbolinks-preview", "")
     else
-      delete @element.dataset.turbolinksPreview
+      @element.removeAttribute("data-turbolinks-preview")
 
   renderSnapshot: (newSnapshot, callback) ->
     currentSnapshot = @getSnapshot(clone: false)


### PR DESCRIPTION
Switches to `Element.setAttribute()` and `removeAttribute()` in favor of using `Element.dataset`, which [isn't supported in IE < 11](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_data_attributes#Issues).

Fixes #21 
