### PR TITLE
Remove 'application/xml' from Request Header

### DIFF
--- a/src/turbolinks/http_request.coffee
+++ b/src/turbolinks/http_request.coffee
@@ -63,7 +63,7 @@ class Turbolinks.HttpRequest
     @xhr = new XMLHttpRequest
     @xhr.open("GET", @url, true)
     @xhr.timeout = @constructor.timeout * 1000
-    @xhr.setRequestHeader("Accept", "text/html, application/xhtml+xml, application/xml")
+    @xhr.setRequestHeader("Accept", "text/html, application/xhtml+xml")
     @xhr.setRequestHeader("Turbolinks-Referrer", @referrer)
     @xhr.onprogress = @requestProgressed
     @xhr.onload = @requestLoaded


### PR DESCRIPTION
This is to fix issue #40 so `format.xml` from within a **respond_to** block doesn't override all other response types.