### PR TITLE
Start HTTP request before changing browser history

### DIFF
--- a/src/turbolinks/browser_adapter.coffee
+++ b/src/turbolinks/browser_adapter.coffee
@@ -12,8 +12,8 @@ class Turbolinks.BrowserAdapter
     @controller.startVisitToLocationWithAction(location, action)
 
   visitStarted: (visit) ->
-    visit.changeHistory()
     visit.issueRequest()
+    visit.changeHistory()
     visit.loadCachedSnapshot()
 
   visitRequestStarted: (visit) ->


### PR DESCRIPTION
Tests still pass, LMK if this breaks things. 

Chrome Timeline *after* this patch - network requests begin 20ms earlier.

![screen shot 2016-03-23 at 3 23 59 pm](https://cloud.githubusercontent.com/assets/845662/13998133/e3482228-f10b-11e5-8351-9016acb8c569.png)
