### PR TITLE
Remove unneccessary clones

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -93,7 +93,7 @@ class Turbolinks.Controller
   cacheSnapshot: ->
     if @shouldCacheSnapshot()
       @notifyApplicationBeforeCachingSnapshot()
-      snapshot = @view.getSnapshot()
+      snapshot = @view.getSnapshot(clone: true)
       @cache.put(@lastRenderedLocation, snapshot)
 
   # Scrolling

--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -10,7 +10,7 @@ class Turbolinks.View
   getCacheControlValue: ->
     @getSnapshot().getCacheControlValue()
 
-  getSnapshot: ({clone} = {clone: true}) ->
+  getSnapshot: ({clone} = {clone: false}) ->
     element = if clone then @element.cloneNode(true) else @element
     Turbolinks.Snapshot.fromElement(element)
 
@@ -30,7 +30,7 @@ class Turbolinks.View
       @element.removeAttribute("data-turbolinks-preview")
 
   renderSnapshot: (newSnapshot, callback) ->
-    currentSnapshot = @getSnapshot(clone: false)
+    currentSnapshot = @getSnapshot()
 
     unless currentSnapshot.hasSameTrackedHeadElementsAsSnapshot(newSnapshot)
       @delegate.viewInvalidated()


### PR DESCRIPTION
Tested on a 4,000-element DOM.

[Before and after](http://imgur.com/a/1JvnJ) - about ~50ms saved.

I'm not sure if these are really necessary - tests still pass, correct me if I'm wrong here.