### PR TITLE
Eliminate clones when caching has been disabled

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -88,7 +88,7 @@ class Turbolinks.Controller
     @cache.get(location)
 
   shouldCacheSnapshot: ->
-    @view.getCacheControlValue() isnt "no-cache"
+    @view.shouldCacheSnapshot()
 
   cacheSnapshot: ->
     if @shouldCacheSnapshot()


### PR DESCRIPTION
This is probably more CoffeeScript than I've ever written in my life, so let me know if this can be organized better.

If the new Snapshot isn't going to be cached, it's more memory-and-time efficient to just insert that Snapshot directly into the page rather than cloning it.