### PR TITLE
Make cloning a cache-level concern, speed up non-cacheable responses

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -3,7 +3,7 @@
 #= require ./history
 #= require ./view
 #= require ./scroll_manager
-#= require ./cache
+#= require ./snapshot_cache
 #= require ./visit
 
 class Turbolinks.Controller
@@ -35,7 +35,7 @@ class Turbolinks.Controller
       @started = false
 
   clearCache: ->
-    @cache = new Turbolinks.Cache 10
+    @cache = new Turbolinks.SnapshotCache 10
 
   visit: (location, options = {}) ->
     location = Turbolinks.Location.wrap(location)
@@ -85,16 +85,17 @@ class Turbolinks.Controller
   # Snapshot cache
 
   getCachedSnapshotForLocation: (location) ->
-    @cache.get(location)
+    snapshot = @cache.get(location)
+    snapshot.clone() if snapshot
 
   shouldCacheSnapshot: ->
-    @view.getCacheControlValue() isnt "no-cache"
+    @view.getSnapshot().isCacheable()
 
   cacheSnapshot: ->
     if @shouldCacheSnapshot()
       @notifyApplicationBeforeCachingSnapshot()
-      snapshot = @view.getSnapshot(clone: true)
-      @cache.put(@lastRenderedLocation, snapshot)
+      snapshot = @view.getSnapshot()
+      @cache.put(@lastRenderedLocation, snapshot.clone())
 
   # Scrolling
 

--- a/src/turbolinks/error_renderer.coffee
+++ b/src/turbolinks/error_renderer.coffee
@@ -14,7 +14,7 @@ class Turbolinks.ErrorRenderer extends Turbolinks.Renderer
 
   activateBodyScriptElements: ->
     for replaceableElement in @getScriptElements()
-      element = @cloneScriptElement(replaceableElement)
+      element = @createScriptElement(replaceableElement)
       replaceableElement.parentNode.replaceChild(element, replaceableElement)
 
   getScriptElements: ->

--- a/src/turbolinks/renderer.coffee
+++ b/src/turbolinks/renderer.coffee
@@ -13,14 +13,14 @@ class Turbolinks.Renderer
   invalidateView: ->
     @delegate.viewInvalidated()
 
-  cloneScriptElement: (element) ->
+  createScriptElement: (element) ->
     if element.getAttribute("data-turbolinks-eval") is "false"
-      element.cloneNode(true)
+      element
     else
-      clonedScriptElement = document.createElement("script")
-      clonedScriptElement.textContent = element.textContent
-      copyElementAttributes(clonedScriptElement, element)
-      clonedScriptElement
+      createdScriptElement = document.createElement("script")
+      createdScriptElement.textContent = element.textContent
+      copyElementAttributes(createdScriptElement, element)
+      createdScriptElement
 
   copyElementAttributes = (destinationElement, sourceElement) ->
     for {name, value} in sourceElement.attributes

--- a/src/turbolinks/snapshot.coffee
+++ b/src/turbolinks/snapshot.coffee
@@ -19,6 +19,11 @@ class Turbolinks.Snapshot
     @head = head ? document.createElement("head")
     @body = body ? document.createElement("body")
 
+  clone: ->
+    new Snapshot
+      head: @head.cloneNode(true)
+      body: @body.cloneNode(true)
+
   getRootLocation: ->
     root = @getSetting("root") ? "/"
     new Turbolinks.Location root
@@ -31,6 +36,9 @@ class Turbolinks.Snapshot
 
   isPreviewable: ->
     @getCacheControlValue() isnt "no-preview"
+
+  isCacheable: ->
+    @getCacheControlValue() isnt "no-cache"
 
   # Private
 

--- a/src/turbolinks/snapshot_cache.coffee
+++ b/src/turbolinks/snapshot_cache.coffee
@@ -1,4 +1,4 @@
-class Turbolinks.Cache
+class Turbolinks.SnapshotCache
   constructor: (@size) ->
     @keys = []
     @snapshots = {}

--- a/src/turbolinks/snapshot_renderer.coffee
+++ b/src/turbolinks/snapshot_renderer.coffee
@@ -5,7 +5,7 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
   constructor: (@currentSnapshot, @newSnapshot) ->
     @currentHeadDetails = new Turbolinks.HeadDetails @currentSnapshot.head
     @newHeadDetails = new Turbolinks.HeadDetails @newSnapshot.head
-    @newBody = @newSnapshot.body.cloneNode(true)
+    @newBody = @newSnapshot.body
 
   render: (callback) ->
     if @trackedElementsAreIdentical()
@@ -33,11 +33,11 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
 
   copyNewHeadStylesheetElements: ->
     for element in @getNewHeadStylesheetElements()
-      document.head.appendChild(element.cloneNode(true))
+      document.head.appendChild(element)
 
   copyNewHeadScriptElements: ->
     for element in @getNewHeadScriptElements()
-      document.head.appendChild(@cloneScriptElement(element))
+      document.head.appendChild(@createScriptElement(element))
 
   removeCurrentHeadProvisionalElements: ->
     for element in @getCurrentHeadProvisionalElements()
@@ -45,7 +45,7 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
 
   copyNewHeadProvisionalElements: ->
     for element in @getNewHeadProvisionalElements()
-      document.head.appendChild(element.cloneNode(true))
+      document.head.appendChild(element)
 
   importBodyPermanentElements: ->
     for replaceableElement in @getNewBodyPermanentElements()
@@ -54,7 +54,7 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
 
   activateBodyScriptElements: ->
     for replaceableElement in @getNewBodyScriptElements()
-      element = @cloneScriptElement(replaceableElement)
+      element = @createScriptElement(replaceableElement)
       replaceableElement.parentNode.replaceChild(element, replaceableElement)
 
   assignNewBody: ->

--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -8,13 +8,9 @@ class Turbolinks.View
 
   getRootLocation: ->
     @getSnapshot().getRootLocation()
-
-  getCacheControlValue: ->
-    @getSnapshot().getCacheControlValue()
-
-  getSnapshot: ({clone} = {clone: false}) ->
-    element = if clone then @element.cloneNode(true) else @element
-    Turbolinks.Snapshot.fromElement(element)
+    
+  getSnapshot: ->
+    Turbolinks.Snapshot.fromElement(@element)
 
   render: ({snapshot, error, isPreview}, callback) ->
     @markAsPreview(isPreview)


### PR DESCRIPTION
This PR makes cloning the snapshots a concern of the Controller. 

Previously, cloning was performed as-needed in several locations. This PR clones all snapshots as they enter and leave the cache. This has a beneficial side-effect of removing unnecessary cloning during rendering when the Snapshot is not cacheable. 

[Before and after, tested on a 4,000-element DOM.](http://imgur.com/a/pl13b) If the response is not cacheable, this PR eliminates a costly ~70ms of `cloneNode` time when rendering the response.

In addition:

* delegate `isCacheable` to the Snapshot to make it similar to how Previews work
* `getSnapshot` no longer needs to know how to clone snapshots
* Reduce areas in the code that need to know about cloning
* Rename Cache to SnapshotCache, to more accurately reflect what it does.