### PR TITLE
Add a public method to change the URL in the browser location bar

### DIFF
--- a/src/turbolinks/index.coffee
+++ b/src/turbolinks/index.coffee
@@ -12,3 +12,8 @@
 
   clearCache: ->
     Turbolinks.controller.clearCache()
+
+  changeURL: (location) ->
+    Turbolinks
+      .controller
+      .pushHistoryWithLocationAndRestorationIdentifier(location, Turbolinks.uuid())


### PR DESCRIPTION
Just to provide some context, in our app we have a modal dialog containing a form. When the modal dialog is being shown we have a different URL (permalink) depending on if we are creating or editing an entry. However, if the user cancels or close the modal dialog, we want to just restore the previous URL (the one corresponding to the same page when the modal is hidden), but we also want to avoid a unnecessary call to `Turbolinks.visit` (because we are sure that nothing has changed in the page that contains the modal dialog).

This PR adds a way to change the URL without invoking `Turbolinks.visit`, so the subsequent request is not fired. This new function helps to change the URL in a Turbolinks-compatible way where this URL change will be part of the navigation history.


Being honest, I'm not sure if the addition of this function to the public API is worth :smiley: 
However, we are including this code in our own application, so I decided to share and see if it's interesting to others. Of course, it would be better for us if we can rely in a function that is part of the public API :relieved: 

What do you think? What would be a good name for this public function?