### PR TITLE
Use getElementById instead of querySelector

### DIFF
--- a/src/turbolinks/snapshot.coffee
+++ b/src/turbolinks/snapshot.coffee
@@ -27,7 +27,7 @@ class Turbolinks.Snapshot
     @getSetting("cache-control")
 
   hasAnchor: (anchor) ->
-    @body.querySelector("##{anchor}")?
+    @body.getElementById(anchor)?
 
   isPreviewable: ->
     @getCacheControlValue() isnt "no-preview"


### PR DESCRIPTION
I noticed that specifying invalid id string as hash breaks turbolinks. My guess says it also happens when restoring (going back) to a page with invalid hash (which possibly user-specified).

Using `getElementById` allows any string to be used (or is it?).

    > document.getElementById('123')
    null
    > document.querySelector('#123')
    SyntaxError: An invalid or illegal string was specified

From what I can tell `@location.anchor` always come from slicing `location.hash`.