### PR TITLE
Add UMD support. Fixes #91

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gem 'coffee-script-source', '~> 1.9.1'
 gem 'eco'
 gem 'uglifier'
 
-gem 'blade', github: 'javan/blade'
+gem 'blade', '~> 0.5.2'
 gem 'blade-sauce_labs_plugin', github: 'javan/blade-sauce_labs_plugin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,33 +8,29 @@ GIT
       faraday
       selenium-webdriver
 
-GIT
-  remote: git://github.com/javan/blade.git
-  revision: 84e843ed5517c8eff61d876dcf4634deebe88aa8
-  specs:
-    blade (0.5.0)
-      activesupport (>= 3.0.0)
-      blade-qunit_adapter (~> 1.20.0)
-      coffee-script (~> 2.4.0)
-      coffee-script-source (~> 1.9.0)
-      curses (~> 1.0.0)
-      eventmachine (~> 1.0.0)
-      faye (= 1.1.1)
-      sprockets (~> 3.2.0)
-      thin (~> 1.6.0)
-      thor (~> 0.19.1)
-      useragent (~> 0.13.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5.1)
+    activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
+    blade (0.5.2)
+      activesupport (>= 3.0.0)
+      blade-qunit_adapter (~> 1.20.0)
+      coffee-script
+      coffee-script-source
+      curses (~> 1.0.0)
+      eventmachine (~> 1.0.0)
+      faye (~> 1.1.1)
+      sprockets (>= 3.0)
+      sprockets-export (~> 0.9.1)
+      thin (~> 1.6.0)
+      thor (~> 0.19.1)
+      useragent (~> 0.16.7)
     blade-qunit_adapter (1.20.0)
     childprocess (0.5.8)
       ffi (~> 1.0, >= 1.0.11)
@@ -42,8 +38,9 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.3)
+    concurrent-ruby (1.0.2)
     cookiejar (0.3.0)
-    curses (1.0.1)
+    curses (1.0.2)
     daemons (1.2.3)
     eco (1.0.0)
       coffee-script
@@ -62,7 +59,7 @@ GEM
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faye (1.1.1)
+    faye (1.1.2)
       cookiejar (>= 0.3.0)
       em-http-request (>= 0.3.0)
       eventmachine (>= 0.12.0)
@@ -70,15 +67,15 @@ GEM
       multi_json (>= 1.0.0)
       rack (>= 1.0.0)
       websocket-driver (>= 0.5.1)
-    faye-websocket (0.10.2)
+    faye-websocket (0.10.3)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.9.10)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.4)
-    multi_json (1.11.2)
+    minitest (5.9.0)
+    multi_json (1.12.0)
     multipart-post (2.0.0)
     rack (1.6.4)
     rake (10.4.2)
@@ -88,8 +85,10 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    sprockets (3.2.0)
-      rack (~> 1.0)
+    sprockets (3.6.0)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-export (0.9.1)
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -101,7 +100,7 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    useragent (0.13.3)
+    useragent (0.16.7)
     websocket (1.2.2)
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
@@ -111,7 +110,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  blade!
+  blade (~> 0.5.2)
   blade-sauce_labs_plugin!
   coffee-script
   coffee-script-source (~> 1.9.1)
@@ -121,4 +120,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.10.6
+   1.12.3

--- a/README.md
+++ b/README.md
@@ -29,31 +29,12 @@ Your Ruby on Rails application can use the [`turbolinks` RubyGem](https://github
 
 The gem also provides server-side support for Turbolinks redirection.
 
-### Installation Using Webpack
+### Installation Using npm
 
-Your application can use the [`turbolinks` npm package](https://www.npmjs.com/package/turbolinks) to install Turbolinks in a [Webpack](http://webpack.github.io/) asset bundle.
+Your application can use the [`turbolinks` npm package](https://www.npmjs.com/package/turbolinks) to install Turbolinks as a module for build tools like [webpack](http://webpack.github.io/).
 
 1. Add the `turbolinks` package to your application: `npm install --save turbolinks`.
-2. Install the [imports loader](https://github.com/webpack/imports-loader) module for webpack: `npm install --save imports-loader`. 
-3. Add `turbolinks` to the `entry` section of webpack.config.js:
-
-    ```js
-    entry: {
-      vendor: [ ...,
-        'turbolinks',
-      ],
-    },
-    ```
-
-4. Set up Turbolinks in the `module.loaders` section of webpack.config.js:
-
-    ```js
-    module: {
-      loaders: [ ...,
-        { test: require.resolve('turbolinks'), loader: 'imports?this=>window' },
-      ],
-    },
-    ```
+2. Require Turbolinks in your JavaScript bundle: `var Turbolinks = require("turbolinks")`.
 
 # Navigating with Turbolinks
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Turbolinks works in all modern desktop and mobile browsers. It depends on the [H
 
 Include [`dist/turbolinks.js`](dist/turbolinks.js) in your application’s JavaScript bundle.
 
+Turbolinks automatically initializes itself when loaded via a standalone `<script>` tag or a traditional concatenated JavaScript bundle. If you load Turbolinks as a CommonJS or AMD module, first require the module, then call the provided `start()` function.
+
 ### Installation Using Ruby on Rails
 
 Your Ruby on Rails application can use the [`turbolinks` RubyGem](https://github.com/turbolinks/turbolinks-rails) to install Turbolinks. This gem contains a Rails engine which integrates seamlessly with the Rails asset pipeline.
@@ -34,8 +36,12 @@ The gem also provides server-side support for Turbolinks redirection.
 Your application can use the [`turbolinks` npm package](https://www.npmjs.com/package/turbolinks) to install Turbolinks as a module for build tools like [webpack](http://webpack.github.io/).
 
 1. Add the `turbolinks` package to your application: `npm install --save turbolinks`.
-2. Require Turbolinks in your JavaScript bundle: `var Turbolinks = require("turbolinks")`.
-3. If you’re using the [turbolinks-ios](https://github.com/turbolinks/turbolinks-ios) or [turbolinks-android](https://github.com/turbolinks/turbolinks-android) adapter, define `Turbolinks` on `window` so it’s available to them globally: `window.Turbolinks = Turbolinks`.
+2. Require and start Turbolinks in your JavaScript bundle:
+
+    ```js
+    var Turbolinks = require("turbolinks")
+    Turbolinks.start()
+    ```
 
 # Navigating with Turbolinks
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Your application can use the [`turbolinks` npm package](https://www.npmjs.com/pa
 
 1. Add the `turbolinks` package to your application: `npm install --save turbolinks`.
 2. Require Turbolinks in your JavaScript bundle: `var Turbolinks = require("turbolinks")`.
+3. If you’re using the [turbolinks-ios](https://github.com/turbolinks/turbolinks-ios) or [turbolinks-android](https://github.com/turbolinks/turbolinks-android) adapter, define `Turbolinks` on `window` so it’s available to them globally: `window.Turbolinks = Turbolinks`.
 
 # Navigating with Turbolinks
 

--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -236,8 +236,3 @@ class Turbolinks.Controller
 
   getRestorationDataForIdentifier: (identifier) ->
     @restorationData[identifier] ?= {}
-
-do ->
-  Turbolinks.controller = controller = new Turbolinks.Controller
-  controller.adapter = new Turbolinks.BrowserAdapter(controller)
-  controller.start()

--- a/src/turbolinks/index.coffee
+++ b/src/turbolinks/index.coffee
@@ -3,6 +3,7 @@
 #= require_self
 #= require ./helpers
 #= require ./controller
+#= require ./start
 
 @Turbolinks =
   supported: do ->

--- a/src/turbolinks/index.coffee
+++ b/src/turbolinks/index.coffee
@@ -1,4 +1,5 @@
 #= require ./BANNER
+#= export Turbolinks
 #= require_self
 #= require ./helpers
 #= require ./controller

--- a/src/turbolinks/start.coffee
+++ b/src/turbolinks/start.coffee
@@ -1,0 +1,24 @@
+Turbolinks.start = ->
+  if installTurbolinks()
+    Turbolinks.controller ?= createController()
+    Turbolinks.controller.start()
+
+installTurbolinks = ->
+  window.Turbolinks ?= Turbolinks
+  window.Turbolinks is Turbolinks
+
+createController = ->
+  controller = new Turbolinks.Controller
+  controller.adapter = new Turbolinks.BrowserAdapter(controller)
+  controller
+
+isModule = ->
+  isCommonJSModule() or isAMDModule()
+
+isCommonJSModule = ->
+  typeof module is "object" and module.exports
+
+isAMDModule = ->
+  typeof define is "function" and define.amd
+
+Turbolinks.start() unless isModule()

--- a/src/turbolinks/start.coffee
+++ b/src/turbolinks/start.coffee
@@ -5,20 +5,14 @@ Turbolinks.start = ->
 
 installTurbolinks = ->
   window.Turbolinks ?= Turbolinks
-  window.Turbolinks is Turbolinks
+  moduleIsInstalled()
 
 createController = ->
   controller = new Turbolinks.Controller
   controller.adapter = new Turbolinks.BrowserAdapter(controller)
   controller
 
-isModule = ->
-  isCommonJSModule() or isAMDModule()
+moduleIsInstalled = ->
+  window.Turbolinks is Turbolinks
 
-isCommonJSModule = ->
-  typeof module is "object" and module.exports
-
-isAMDModule = ->
-  typeof define is "function" and define.amd
-
-Turbolinks.start() unless isModule()
+Turbolinks.start() if moduleIsInstalled()


### PR DESCRIPTION
Define UMD module for Turbolinks to support script / module build tools like webpack, browserify, require.js, etc.