### PR TITLE
Use `Element.getAttribute()` to get a visitable link's href. Fixes #110

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -217,7 +217,7 @@ class Turbolinks.Controller
       Turbolinks.closest(node, "a[href]:not([target])")
 
   getVisitableLocationForLink: (link) ->
-    location = new Turbolinks.Location link.href
+    location = new Turbolinks.Location link.getAttribute("href")
     location if @locationIsVisitable(location)
 
   getActionForLink: (link) ->

--- a/test/src/fixtures/navigation.html
+++ b/test/src/fixtures/navigation.html
@@ -14,6 +14,8 @@
       <p data-turbolinks="false"><a id="same-origin-unannotated-link-inside-false-container" href="/fixtures/one.html">Same-origin unannotated link inside data-turbolinks=false container</a></p>
       <p data-turbolinks="false"><a id="same-origin-true-link-inside-false-container" href="/fixtures/one.html" data-turbolinks="true">Same-origin data-turbolinks=true link inside data-turbolinks=false container</a></p>
       <p><a id="cross-origin-unannotated-link" href="about:blank">Cross-origin unannotated link</a></p>
+      <svg><text><a id="same-origin-link-inside-svg-element" href="/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
+      <svg><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
     </section>
   </body>
 </html>

--- a/test/src/modules/navigation_tests.coffee
+++ b/test/src/modules/navigation_tests.coffee
@@ -45,6 +45,18 @@ navigationTest "following a cross-origin unannotated link", (assert, session, do
     assert.equal(navigation.action, "load")
     done()
 
+navigationTest "following a same-origin link inside an SVG element", (assert, session, done) ->
+  session.clickSelector "#same-origin-link-inside-svg-element", (navigation) ->
+    assert.equal(navigation.location.pathname, "/fixtures/one.html")
+    assert.equal(navigation.action, "push")
+    done()
+
+navigationTest "following a cross-origin link inside an SVG element", (assert, session, done) ->
+  session.clickSelector "#cross-origin-link-inside-svg-element", (navigation) ->
+    assert.equal(navigation.location, "about:blank")
+    assert.equal(navigation.action, "load")
+    done()
+
 navigationTest "clicking the back button", (assert, session, done) ->
   session.clickSelector "#same-origin-unannotated-link", ->
     session.waitForEvent "turbolinks:load", ->


### PR DESCRIPTION
The `href` property of an SVG <a> element is an `SVGAnimatedString` (not a `String`). This prevented it from being extracted by `Turbolinks.Location`, resulting in a broken link.

Use `Element.getAttribute("href")` to ensure the result is a `String`.