### PR TITLE
Use an HTTPs git link for a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'eco'
 gem 'uglifier'
 
 gem 'blade', '~> 0.5.2'
-gem 'blade-sauce_labs_plugin', github: 'javan/blade-sauce_labs_plugin'
+gem 'blade-sauce_labs_plugin', git: 'https://github.com/javan/blade-sauce_labs_plugin.git'


### PR DESCRIPTION
Using the `github:` option in a Gemfile is vulnerable to MITM attacks according to [bundler's documentation](http://bundler.io/git.html). This change uses the `git:` option with an HTTPs URL instead, which is not vulnerable. 