### PR TITLE
Provide a method to change the progress bar delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,15 @@ Turbolinks.clearCache()
 
 Removes all entries from the Turbolinks page cache. Call this when state has changed on the server that may affect cached pages.
 
+## Turbolinks.setProgressBarDelay
+
+Usage:
+```js
+Turbolinks.setProgressBarDelay(0)
+```
+
+Sets the delay after which the [progress bar](#displaying-progress)  will appear, in miliseconds.
+
 ## Turbolinks.supported
 
 Usage:

--- a/src/turbolinks/browser_adapter.coffee
+++ b/src/turbolinks/browser_adapter.coffee
@@ -3,10 +3,10 @@
 
 class Turbolinks.BrowserAdapter
   {NETWORK_FAILURE, TIMEOUT_FAILURE} = Turbolinks.HttpRequest
-  PROGRESS_BAR_DELAY = 500
 
   constructor: (@controller) ->
     @progressBar = new Turbolinks.ProgressBar
+    @progressBarDelay = 500
 
   visitProposedToLocationWithAction: (location, action) ->
     @controller.startVisitToLocationWithAction(location, action)
@@ -48,7 +48,7 @@ class Turbolinks.BrowserAdapter
   # Private
 
   showProgressBarAfterDelay: ->
-    @progressBarTimeout = setTimeout(@showProgressBar, PROGRESS_BAR_DELAY)
+    @progressBarTimeout = setTimeout(@showProgressBar, @progressBarDelay)
 
   showProgressBar: =>
     @progressBar.show()

--- a/src/turbolinks/index.coffee
+++ b/src/turbolinks/index.coffee
@@ -14,3 +14,7 @@
 
   clearCache: ->
     Turbolinks.controller.clearCache()
+
+  setProgressBarDelay: (delay) ->
+    if Turbolinks.controller.adapter.hasOwnProperty("progressBarDelay")
+      Turbolinks.controller.adapter.progressBarDelay = delay


### PR DESCRIPTION
This is based off of discussion in issue #120. Under this scheme, the user may use `Turbolinks.setProgressBarDelay` to set the delay after which the progress bar appears. 
