### PR TITLE
Remove reference to "beta" version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Turbolinks automatically initializes itself when loaded via a standalone `<scrip
 
 Your Ruby on Rails application can use the [`turbolinks` RubyGem](https://github.com/turbolinks/turbolinks-rails) to install Turbolinks. This gem contains a Rails engine which integrates seamlessly with the Rails asset pipeline.
 
-1. Add the `turbolinks` gem, version 5, to your Gemfile: `gem 'turbolinks', '~> 5.0.0.beta'`
+1. Add the `turbolinks` gem, version 5, to your Gemfile: `gem 'turbolinks', '~> 5.0.0'`
 2. Run `bundle install`.
 3. Add `//= require turbolinks` to your JavaScript manifest file (usually found at `app/assets/javascripts/application.js`).
 


### PR DESCRIPTION
Although the old command was valid, it's now slightly misleading to display this as "in beta", in the README!