### PR TITLE
Fix behavior of data-turbolinks-preview attribute

### DIFF
--- a/src/turbolinks/visit.coffee
+++ b/src/turbolinks/visit.coffee
@@ -56,7 +56,7 @@ class Turbolinks.Visit
 
   loadCachedSnapshot: ->
     if snapshot = @getCachedSnapshot()
-      isPreview = @shouldIssueRequest()
+      isPreview = not @shouldIssueRequest()
       @render ->
         @cacheSnapshot()
         @controller.render({snapshot, isPreview}, @performScroll)

--- a/test/src/modules/rendering_tests.coffee
+++ b/test/src/modules/rendering_tests.coffee
@@ -108,6 +108,21 @@ renderingTest "error pages", (assert, session, done) ->
       assert.equal(session.element.document.body.textContent, "Not found")
       done()
 
+renderingTest "set data-turbolinks-preview", (assert, session, done) ->
+  session.clickSelector "#same-origin-link", ->
+    session.waitForEvent "turbolinks:render", ->
+      session.goBack()
+      session.waitForEvent "turbolinks:render", ->
+        assert.ok(session.element.document.documentElement.hasAttribute("data-turbolinks-preview"))
+        session.clickSelector "#same-origin-link", ->
+          session.waitForEvent "turbolinks:render", ->
+            assert.notOk(session.element.document.documentElement.hasAttribute("data-turbolinks-preview"))
+            session.goBack()
+            session.waitForEvent "turbolinks:render", ->
+              session.goForward()
+              assert.ok(session.element.document.documentElement.hasAttribute("data-turbolinks-preview"))
+              done()
+
 getAssetElements = (document = document) ->
   selectChildren document.head, (el) -> match(el, "script, style, link[rel=stylesheet]")
 


### PR DESCRIPTION
I'm using AngularJS with Rails5 and I found the cache of turbolinks may cause angular's re-bootstrap problem when click the back button of browser. 

I tried to solve it with the _data-turbolinks-preview_ attribute but it seems that the attribute doesn't work as it was described at [Detecting When a Preview is Visible](https://github.com/turbolinks/turbolinks#detecting-when-a-preview-is-visible). So I fixed it and added a testcase:)