### PR TITLE
Fire "turbolinks:load" event even for unsupported browsers [Fixes #130]

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -15,7 +15,7 @@ class Turbolinks.Controller
     @clearCache()
 
   start: ->
-    if Turbolinks.supported and not @started
+    unless @started
       addEventListener("click", @clickCaptured, true)
       addEventListener("DOMContentLoaded", @pageLoaded, false)
       @scrollManager.start()

--- a/src/turbolinks/history.coffee
+++ b/src/turbolinks/history.coffee
@@ -23,8 +23,9 @@ class Turbolinks.History
     @update("push", location, restorationIdentifier)
 
   replace: (location, restorationIdentifier) ->
-    location = Turbolinks.Location.wrap(location)
-    @update("replace", location, restorationIdentifier)
+    if Turbolinks.supported
+      location = Turbolinks.Location.wrap(location)
+      @update("replace", location, restorationIdentifier)
 
   # Event handlers
 

--- a/test/src/fixtures/event.html
+++ b/test/src/fixtures/event.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Event</title>
+    <script>
+      window.history.pushState = null;
+      document.addEventListener("turbolinks:load", function() {
+        window.turbolinksLoadFired = true;
+      })
+    </script>
+    <script src="/turbolinks.js" data-turbolinks-track="reload"></script>
+  </head>
+  <body></body>
+</html>

--- a/test/src/modules/event_tests.coffee
+++ b/test/src/modules/event_tests.coffee
@@ -1,0 +1,11 @@
+QUnit.module "Event"
+
+eventTest = (name, callback) ->
+  sessionTest name, (assert, session, done) ->
+    session.goToLocation "/fixtures/event.html", (navigation) ->
+      assert.equal(navigation.location.pathname, "/fixtures/event.html")
+      callback(assert, session, done)
+
+eventTest "fires turbolinks:load, even for unsupported browsers", (assert, session, done) ->
+  assert.equal(session.element.window.turbolinksLoadFired, true)
+  done()


### PR DESCRIPTION
This is an attempt to fix the issue mentioned in #130, where `turbolinks:load` doesn't get fired for unsupported browsers.

Not sure if this is the best way to go about it, but this PR moves the `Turbolinks.supported` conditional to `history.replace()` (which is where things fall apart when run on an unsupported browser) so that the initialization process which fires the event in question still runs its course.

I've added a test as well to assert that the event gets fired on a browser without `windows.pushState`. Forgive my ignorance since this is my first time to use blade, but I'm not sure if I'm doing this the right way either! 

I appreciate any pointers in case this is completely off track! 🙇 
