### PR TITLE
Add support for scrolling to named anchors

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -100,7 +100,7 @@ class Turbolinks.Controller
   # Scrolling
 
   scrollToAnchor: (anchor) ->
-    if element = document.getElementById(anchor)
+    if element = document.getElementById(anchor) || document.querySelector("[name=#{anchor}]")
       @scrollToElement(element)
     else
       @scrollToPosition(x: 0, y: 0)

--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -100,7 +100,7 @@ class Turbolinks.Controller
   # Scrolling
 
   scrollToAnchor: (anchor) ->
-    if element = document.getElementById(anchor) || document.querySelector("[name=#{anchor}]")
+    if element = document.getElementById(anchor) || document.querySelector("a[name=#{anchor}]")
       @scrollToElement(element)
     else
       @scrollToPosition(x: 0, y: 0)


### PR DESCRIPTION
This pull request adds support for scrolling to named anchors, so that calling `Turbolinks.visit('/path#name')`, when the target page includes `<a name="name"></a>`, behaves the same as if the page included an element with an ID of `name`.

The current behaviour ignores named anchors as demonstrated [here](https://powerful-wildwood-35478.herokuapp.com).

I understand that using anchors in this way is rather old fashioned (indeed it is obsolete in HTML5), but visiting `/path#name` directly versus via Turbolinks results in different behaviour, so I thought it'd be worth fixing.

I'd be happy to add tests if you think it is necessary, but I may need a pointer or two.
