### PR TITLE
Fix link with download attr is visited

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -214,7 +214,7 @@ class Turbolinks.Controller
 
   getVisitableLinkForNode: (node) ->
     if @nodeIsVisitable(node)
-      Turbolinks.closest(node, "a[href]:not([target])")
+      Turbolinks.closest(node, "a[href]:not([target]):not([download])")
 
   getVisitableLocationForLink: (link) ->
     location = new Turbolinks.Location link.getAttribute("href")


### PR DESCRIPTION
Clicking on `<a download="...">` will download linked file on modern browsers.
But currently turbolinks captures and visits linked url, so for example mp4 video will be played in current tab.
This PR fixes it by exclude a tag with download attr.