### PR TITLE
Improve handling of URLs with extensions and fragment identifiers

### DIFF
--- a/src/turbolinks/location.coffee
+++ b/src/turbolinks/location.coffee
@@ -22,7 +22,7 @@ class Turbolinks.Location
     @absoluteURL.split("/", 3).join("/")
 
   getPath: ->
-    @absoluteURL.match(/\/\/[^/]*(\/[^?;]*)/)?[1] ? "/"
+    @requestURL.match(/\/\/[^/]*(\/[^?;]*)/)?[1] ? "/"
 
   getPathComponents: ->
     @getPath().split("/").slice(1)

--- a/test/src/fixtures/navigation.html
+++ b/test/src/fixtures/navigation.html
@@ -13,7 +13,7 @@
       <p><a id="same-origin-false-link" href="/fixtures/one.html" data-turbolinks="false">Same-origin data-turbolinks=false link</a></p>
       <p data-turbolinks="false"><a id="same-origin-unannotated-link-inside-false-container" href="/fixtures/one.html">Same-origin unannotated link inside data-turbolinks=false container</a></p>
       <p data-turbolinks="false"><a id="same-origin-true-link-inside-false-container" href="/fixtures/one.html" data-turbolinks="true">Same-origin data-turbolinks=true link inside data-turbolinks=false container</a></p>
-      <p><a id="same-origin-id-link" href="/fixtures/one.html#element-id" data-turbolinks="true">Same-origin link with ID hash</a></p>
+      <p><a id="same-origin-anchored-link" href="/fixtures/one.html#element-id">Same-origin anchored link</a></p>
       <p><a id="cross-origin-unannotated-link" href="about:blank">Cross-origin unannotated link</a></p>
       <p><a id="same-origin-targeted-link" href="/fixtures/one.html" target="_blank">Same-origin targeted link</a></p>
       <p><a id="same-origin-download-link" href="/fixtures/one.html" download="one.html">Same-origin download link</a></p>

--- a/test/src/fixtures/navigation.html
+++ b/test/src/fixtures/navigation.html
@@ -13,6 +13,7 @@
       <p><a id="same-origin-false-link" href="/fixtures/one.html" data-turbolinks="false">Same-origin data-turbolinks=false link</a></p>
       <p data-turbolinks="false"><a id="same-origin-unannotated-link-inside-false-container" href="/fixtures/one.html">Same-origin unannotated link inside data-turbolinks=false container</a></p>
       <p data-turbolinks="false"><a id="same-origin-true-link-inside-false-container" href="/fixtures/one.html" data-turbolinks="true">Same-origin data-turbolinks=true link inside data-turbolinks=false container</a></p>
+      <p><a id="same-origin-id-link" href="/fixtures/one.html#element-id" data-turbolinks="true">Same-origin link with ID hash</a></p>
       <p><a id="cross-origin-unannotated-link" href="about:blank">Cross-origin unannotated link</a></p>
       <p><a id="same-origin-targeted-link" href="/fixtures/one.html" target="_blank">Same-origin targeted link</a></p>
       <p><a id="same-origin-download-link" href="/fixtures/one.html" download="one.html">Same-origin download link</a></p>

--- a/test/src/fixtures/one.html
+++ b/test/src/fixtures/one.html
@@ -8,6 +8,8 @@
   </head>
   <body>
     <h1>One</h1>
-    <p id="element-id">An element with an ID</p>
+
+    <!--styles ensure that the element will be scrolled to top when navigated to via an anchored link -->
+    <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
   </body>
 </html>

--- a/test/src/fixtures/one.html
+++ b/test/src/fixtures/one.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <h1>One</h1>
+    <p id="element-id">An element with an ID</p>
   </body>
 </html>

--- a/test/src/helpers/assert_helpers.coffee
+++ b/test/src/helpers/assert_helpers.coffee
@@ -1,0 +1,4 @@
+# An element has been "scrolledTo" if its position from the top of the viewport is between -1 and 1 pixels.
+QUnit.assert.scrolledTo = (element, message) ->
+  positionFromTop = element.getBoundingClientRect().top
+  @push(-1 < positionFromTop < 1, positionFromTop, '(-1, 1)', message)

--- a/test/src/modules/navigation_tests.coffee
+++ b/test/src/modules/navigation_tests.coffee
@@ -39,8 +39,8 @@ navigationTest "following a same-origin data-turbolinks=true link inside a data-
     assert.equal(navigation.action, "push")
     done()
 
-navigationTest "following a same-origin link with ID hash", (assert, session, done) ->
-  session.clickSelector "#same-origin-id-link", (navigation) ->
+navigationTest "following a same-origin anchored link", (assert, session, done) ->
+  session.clickSelector "#same-origin-anchored-link", (navigation) ->
     session.waitForEvent "turbolinks:load", ->
       assert.equal(navigation.location.pathname, "/fixtures/one.html")
       assert.equal(navigation.location.hash, "#element-id")

--- a/test/src/modules/navigation_tests.coffee
+++ b/test/src/modules/navigation_tests.coffee
@@ -39,6 +39,14 @@ navigationTest "following a same-origin data-turbolinks=true link inside a data-
     assert.equal(navigation.action, "push")
     done()
 
+navigationTest "following a same-origin link with ID hash", (assert, session, done) ->
+  session.clickSelector "#same-origin-id-link", (navigation) ->
+    session.waitForEvent "turbolinks:load", ->
+      assert.equal(navigation.location.pathname, "/fixtures/one.html")
+      assert.equal(navigation.location.hash, "#element-id")
+      assert.equal(navigation.action, "push")
+      done()
+
 navigationTest "following a cross-origin unannotated link", (assert, session, done) ->
   session.clickSelector "#cross-origin-unannotated-link", (navigation) ->
     assert.equal(navigation.location, "about:blank")

--- a/test/src/modules/navigation_tests.coffee
+++ b/test/src/modules/navigation_tests.coffee
@@ -45,6 +45,7 @@ navigationTest "following a same-origin anchored link", (assert, session, done) 
       assert.equal(navigation.location.pathname, "/fixtures/one.html")
       assert.equal(navigation.location.hash, "#element-id")
       assert.equal(navigation.action, "push")
+      assert.scrolledTo(session.element.document.getElementById('element-id'))
       done()
 
 navigationTest "following a cross-origin unannotated link", (assert, session, done) ->


### PR DESCRIPTION
Turbolinks is currently ignoring URLs which include an extension as well as a fragment identifier. This is because it will only handle URLs that point to HTML resources, and in this case, the URL is wrongly interpreted as being non-HTML.

A `Location`'s [`isHTML`](https://github.com/turbolinks/turbolinks/blob/c23dbe1beb0f220ada7f422abbf08943a864066a/src/turbolinks/location.coffee#L36) method returns true if its URL ends with an HTML extension (htm, html, or xhtml), or if it has no extension at all. However, if the URL has an HTML extension _and_ a fragment identifier, `isHTML` will be false because it deems everything after the last `.` to be part of the extension. For example the extension of `http://example.com/index.html#foo` would be `.html#foo`. This does not match any of the acceptable extensions, and therefore `isHTML` will return false and the URL will not be handled.

I have added a demo of this behaviour here: https://thawing-hollows-51529.herokuapp.com/ Notice that clicking on the link to `page_2.html#foo` performs a full page load rather than a Turbolinks load.

The proposed solution in this pull request is to use the `requestURL`as the basis for retrieving the extension as it excludes the fragment identifier.