### PR TITLE
Throttle scroll handler

### DIFF
--- a/src/turbolinks/helpers.coffee
+++ b/src/turbolinks/helpers.coffee
@@ -20,6 +20,12 @@ closest = do ->
 Turbolinks.defer = (callback) ->
   setTimeout(callback, 1)
 
+Turbolinks.throttle = (fn) ->
+  request = null
+  (args...) ->
+    request ?= requestAnimationFrame =>
+      request = null
+      fn.apply(this, args)
 
 Turbolinks.dispatch = (eventName, {target, cancelable, data} = {}) ->
   event = document.createEvent("Events")

--- a/src/turbolinks/scroll_manager.coffee
+++ b/src/turbolinks/scroll_manager.coffee
@@ -1,5 +1,6 @@
 class Turbolinks.ScrollManager
   constructor: (@delegate) ->
+    @onScroll = Turbolinks.throttle(@onScroll).bind(this)
 
   start: ->
     unless @started
@@ -18,7 +19,7 @@ class Turbolinks.ScrollManager
   scrollToPosition: ({x, y}) ->
     window.scrollTo(x, y)
 
-  onScroll: (event) =>
+  onScroll: (event) ->
     @updatePosition(x: window.pageXOffset, y: window.pageYOffset)
 
   # Private


### PR DESCRIPTION
Limit `onScroll` to once per animation frame to decrease page reflows (`window.pageXOffset` / `window.pageYOffset` cause them) and improve FPS performance when scrolling.