### PR TITLE
If page is interactive, fire pageLoaded() immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Turbolinks emits events that allow you to track the navigation lifecycle and res
 
 * `turbolinks:render` fires after Turbolinks renders the page. This event fires twice during an application visit to a cached location: once after rendering the cached version, and again after rendering the fresh version.
 
-* `turbolinks:load` fires once after the initial page load, and again after every Turbolinks visit. Access visit timing metrics with the `event.data.timing` object.
+* `turbolinks:load` fires once the first time Turbolinks is loaded, and again after every Turbolinks visit. Access visit timing metrics with the `event.data.timing` object.
 
 # Contributing to Turbolinks
 

--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -17,12 +17,12 @@ class Turbolinks.Controller
   start: ->
     unless @started
       addEventListener("click", @clickCaptured, true)
+      @startHistory()
       if document.readyState is "loading"
         addEventListener("DOMContentLoaded", @pageLoaded, false)
       else
         @pageLoaded()
       @scrollManager.start()
-      @startHistory()
       @started = true
       @enabled = true
 

--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -17,7 +17,10 @@ class Turbolinks.Controller
   start: ->
     unless @started
       addEventListener("click", @clickCaptured, true)
-      addEventListener("DOMContentLoaded", @pageLoaded, false)
+      if document.readyState is "loading"
+        addEventListener("DOMContentLoaded", @pageLoaded, false)
+      else
+        @pageLoaded()
       @scrollManager.start()
       @startHistory()
       @started = true


### PR DESCRIPTION
When using Turbolinks with the `async` script attribute, Turbolinks may
execute after DOMContentLoaded. To fix this, we only attach a handler
to DOMContentLoaded if the readystate is not "loading" (that is to say,
it is "interactive" or "complete"). Otherwise, we fire the pageLoaded
event immediately without installing the handler.

This changes Turbolinks interaction with `defer` scripts. After this
change, an `async` Turbolinks script may execute *before* `defer`ed
scripts. This is because the browser executes all `defer` scripts *before*
the DOMContentLoaded event. Previously, Turbolinks would always execute
after these scripts, but may now execute before them in some cases
depending on when Turbolinks has finished downloading.