### PR TITLE
Revert "If page is interactive, fire pageLoaded() immediately"

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Turbolinks emits events that allow you to track the navigation lifecycle and res
 
 * `turbolinks:render` fires after Turbolinks renders the page. This event fires twice during an application visit to a cached location: once after rendering the cached version, and again after rendering the fresh version.
 
-* `turbolinks:load` fires once the first time Turbolinks is loaded, and again after every Turbolinks visit. Access visit timing metrics with the `event.data.timing` object.
+* `turbolinks:load` fires once after the initial page load, and again after every Turbolinks visit. Access visit timing metrics with the `event.data.timing` object.
 
 # Contributing to Turbolinks
 

--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -17,12 +17,9 @@ class Turbolinks.Controller
   start: ->
     if Turbolinks.supported and not @started
       addEventListener("click", @clickCaptured, true)
-      @startHistory()
-      if document.readyState is "loading"
-        addEventListener("DOMContentLoaded", @pageLoaded, false)
-      else
-        @pageLoaded()
+      addEventListener("DOMContentLoaded", @pageLoaded, false)
       @scrollManager.start()
+      @startHistory()
       @started = true
       @enabled = true
 


### PR DESCRIPTION
Reverts: turbolinks/turbolinks#274
Fixes: https://github.com/turbolinks/turbolinks#278
Reason: https://github.com/turbolinks/turbolinks/issues/278#issuecomment-298930676