### PR TITLE
Add flag to indicate initial page loads

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -136,7 +136,7 @@ class Turbolinks.Controller
 
   pageLoaded: =>
     @lastRenderedLocation = @location
-    @notifyApplicationAfterPageLoad()
+    @notifyApplicationAfterPageLoad(undefined, true)
 
   clickCaptured: =>
     removeEventListener("click", @clickBubbled, false)
@@ -179,8 +179,8 @@ class Turbolinks.Controller
   notifyApplicationAfterRender: ->
     Turbolinks.dispatch("turbolinks:render")
 
-  notifyApplicationAfterPageLoad: (timing = {}) ->
-    Turbolinks.dispatch("turbolinks:load", data: { url: @location.absoluteURL, timing })
+  notifyApplicationAfterPageLoad: (timing = {}, initial = false) ->
+    Turbolinks.dispatch("turbolinks:load", data: { initialPageLoad: initial, url: @location.absoluteURL, timing })
 
   # Private
 
@@ -199,7 +199,7 @@ class Turbolinks.Controller
     visit
 
   visitCompleted: (visit) ->
-    @notifyApplicationAfterPageLoad(visit.getTimingMetrics())
+    @notifyApplicationAfterPageLoad(visit.getTimingMetrics(), false)
 
   clickEventIsSignificant: (event) ->
     not (

--- a/test/src/modules/navigation_tests.coffee
+++ b/test/src/modules/navigation_tests.coffee
@@ -3,13 +3,16 @@ QUnit.module "Navigation"
 navigationTest = (name, callback) ->
   sessionTest name, (assert, session, done) ->
     session.goToLocation "/fixtures/navigation.html", (navigation) ->
+      session.waitForEvent "turbolinks:load", (event) ->
+        assert.ok( typeof event.data.initialPageLoad != 'undefined' , 'initialPageLoad must be present')
       assert.equal(navigation.location.pathname, "/fixtures/navigation.html")
       assert.equal(navigation.action, "load")
       callback(assert, session, done)
 
 navigationTest "following a same-origin unannotated link", (assert, session, done) ->
   session.clickSelector "#same-origin-unannotated-link", (navigation) ->
-    session.waitForEvent "turbolinks:load", ->
+    session.waitForEvent "turbolinks:load", (event) ->
+      assert.equal(event.data.initialPageLoad, false)
       assert.equal(navigation.location.pathname, "/fixtures/one.html")
       assert.equal(navigation.action, "push")
       done()


### PR DESCRIPTION
This adds a boolean flag event.data.initialPageLoad to the
turbolinks:load event to indicate if it is fired on
and initial page load.