### PR TITLE
Prevent autofocus on preview

### DIFF
--- a/src/turbolinks/snapshot_renderer.coffee
+++ b/src/turbolinks/snapshot_renderer.coffee
@@ -12,7 +12,7 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
       @mergeHead()
       @renderView =>
         @replaceBody()
-        @focusFirstAutofocusableElement()
+        @focusFirstAutofocusableElement() unless @newSnapshot.isPreview
         callback()
     else
       @invalidateView()

--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -8,12 +8,12 @@ class Turbolinks.View
 
   getRootLocation: ->
     @getSnapshot().getRootLocation()
-    
+
   getSnapshot: ->
     Turbolinks.Snapshot.fromElement(@element)
 
-  render: ({snapshot, error, isPreview}, callback) ->
-    @markAsPreview(isPreview)
+  render: ({snapshot, error}, callback) ->
+    @markAsPreview(snapshot?.isPreview)
     if snapshot?
       @renderSnapshot(snapshot, callback)
     else

--- a/src/turbolinks/visit.coffee
+++ b/src/turbolinks/visit.coffee
@@ -56,12 +56,12 @@ class Turbolinks.Visit
 
   loadCachedSnapshot: ->
     if snapshot = @getCachedSnapshot()
-      isPreview = @shouldIssueRequest()
+      snapshot.isPreview = @shouldIssueRequest()
       @render ->
         @cacheSnapshot()
-        @controller.render({snapshot, isPreview}, @performScroll)
+        @controller.render({snapshot}, @performScroll)
         @adapter.visitRendered?(this)
-        @complete() unless isPreview
+        @complete() unless snapshot.isPreview
 
   loadResponse: ->
     if @response?

--- a/test/src/fixtures/one.html
+++ b/test/src/fixtures/one.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <h1>One</h1>
+    <input autofocus>
   </body>
 </html>

--- a/test/src/modules/rendering_tests.coffee
+++ b/test/src/modules/rendering_tests.coffee
@@ -102,6 +102,26 @@ renderingTest "does not evaluate data-turbolinks-eval=false scripts", (assert, s
       assert.equal(session.element.window.bodyScriptEvaluationCount, null)
       done()
 
+renderingTest "focusses an autofocus field", (assert, session, done) ->
+  session.clickSelector "#same-origin-link", ->
+    session.waitForEvent "turbolinks:render", ->
+      doc = session.element.document
+      assert.equal(doc.querySelector('[autofocus]'), doc.activeElement)
+      done()
+
+renderingTest "does not autofocus a field on a preview", (assert, session, done) ->
+  session.clickSelector "#same-origin-link", ->
+    session.waitForEvent "turbolinks:load", ->
+      session.goBack()
+      session.waitForEvent "turbolinks:load", ->
+        session.clickSelector "#same-origin-link", ->
+          session.waitForEvent "turbolinks:render", ->
+            doc = session.element.document
+            assert.notEqual(doc.activeElement, doc.querySelector('[autofocus]'))
+            session.waitForEvent "turbolinks:render", ->
+              assert.equal(doc.activeElement, doc.querySelector('[autofocus]'))
+              done()
+
 renderingTest "error pages", (assert, session, done) ->
   session.clickSelector "#nonexistent-link", ->
     session.waitForEvent "turbolinks:render", ->


### PR DESCRIPTION
This pull request prevents autofocusing fields in Turbolinks previews, as detailed in: https://github.com/turbolinks/turbolinks/issues/290.

To achieve this, an `isPreview` flag is set on the snapshot when it is retrieved from the cache. The `SnapshotRenderer` can then decide whether or not to call `focusFirstAutofocusableElement`. This has a nice side-effect of cleaning up `View#render` and `Controller#render`.

I have added a couple of rendering tests which pass intermittently (FWIW I think I getter a better success rate with Safari). I think there is a race-condition (or something) with the [`cancelRender`](https://github.com/turbolinks/turbolinks/blob/master/src/turbolinks/visit.coffee#L156) method. Commenting it out results in consistent behaviour. Any pointers on this?