### PR TITLE
Scrolling to an anchor on a redirect doesn't work

### DIFF
--- a/src/turbolinks/browser_adapter.coffee
+++ b/src/turbolinks/browser_adapter.coffee
@@ -39,9 +39,6 @@ class Turbolinks.BrowserAdapter
   visitRequestFinished: (visit) ->
     @hideProgressBar()
 
-  visitCompleted: (visit) ->
-    visit.followRedirect()
-
   pageInvalidated: ->
     @reload()
 

--- a/src/turbolinks/visit.coffee
+++ b/src/turbolinks/visit.coffee
@@ -72,6 +72,7 @@ class Turbolinks.Visit
           @adapter.visitRendered?(this)
           @fail()
         else
+          @followRedirect()
           @controller.render(snapshot: @response, @performScroll)
           @adapter.visitRendered?(this)
           @complete()


### PR DESCRIPTION
## Problem

Currently, if you do something like:

```ruby
def show
  redirect_to root_url(anchor: "home_tabs")
end
```

and visit the page with turbolinks, the browser will fail to scroll down to the specified anchor:

### Current

<img src=https://user-images.githubusercontent.com/104138/32538246-af4851ce-c4a8-11e7-8bc3-c66e44b62c3d.gif width=500>

### Expected

<img src=https://user-images.githubusercontent.com/104138/32538254-b567486c-c4a8-11e7-87f4-015bdca2209c.gif width=500>

## Cause

The cause seems to be that the callback `performScroll()` gets run _before_ `followRedirect()` has a chance to update `@location` to the final URL:


```coffee
loadResponse: ->
  ...
  @controller.render(snapshot: @response, @performScroll) # adds @performScroll as callback
  ...
  @complete() # triggers @adapter.visitCompleted() which triggers followRedirect()

followRedirect: ->
  if @redirectedToLocation and not @followedRedirect
    @location = @redirectedToLocation # Location is updated, but too late
    ...

scrollToAnchor: ->
  if @location.anchor? # @location is still the URL _before_ the redirect here
    @controller.scrollToAnchor(@location.anchor)
```

## Proposed solution

I admit to not fully knowing the background of needing to trigger `visitRendered` and `visitCompleted` on the adapter, so the proposal may be way off point, but basically it ensures that `followRedirect()` is called _before_ any scrolling is done, by calling it directly from within `loadResponse` before `@controller.render()`.

(I'm also not sure how to go about adding a test for this, as it kind of requires a server side component, so forgive the test-less PR 🙇 )
