### PR TITLE
Improve compatibility with webcomponents.js (connectedCallback)

### DIFF
--- a/src/turbolinks/snapshot_renderer.coffee
+++ b/src/turbolinks/snapshot_renderer.coffee
@@ -58,7 +58,7 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
       replaceableElement.parentNode.replaceChild(element, replaceableElement)
 
   assignNewBody: ->
-    document.body = @newBody
+    document.documentElement.replaceChild(@newBody, document.body)
 
   focusFirstAutofocusableElement: ->
     @findFirstAutofocusableElement()?.focus()


### PR DESCRIPTION
### Background

[Custom Elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements) are a great fit for Turbolinks (and are rightfully mentioned in the Turbolinks README). Unfortunately, more often than not it's still required to use the webcomponents.js [Custom Elements polyfill](https://github.com/webcomponents/custom-elements) to support browsers other than Chrome and Safari 11.

This, in itself, is not much of a problem. However, I noticed that on browsers that need to fall back to the polyfill, my custom elements' `connectedCallback` methods are not called after following a link, breaking them all. 😞 

### The Problem

When visiting a new page, Turbolinks currently replaces the body by setting `document.body`:

```coffeescript
  assignNewBody: ->
    document.body = @newBody
```

However, the polyfill cannot detect `document.body` changes (https://github.com/webcomponents/custom-elements/issues/126). So it will not be able to walk the DOM and call the `connectedCallback`methods of all custom elements.

### The Solution

We can make the webcomponents.js polyfill aware of the body change by simply using `Element.prototype.replaceChild` instead:

```coffeescript
  assignNewBody: ->
    document.documentElement.replaceChild(@newBody, document.body)
```

This version (implemented by this PR) is totally equivalent to setting `document.body`, but `replaceChild` is patched by the polyfill, so `connectedCallback` works as expected. 

There are no disadvantages to this change. As `replaceChild` is supported on all browsers including IE back to version 6, no new browser incompatibilities are introduced.