### PR TITLE
Warn when loading Turbolinks from a <script> inside <body>

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Your application can use the [`turbolinks` npm package](https://www.npmjs.com/pa
 [Building Your Turbolinks Application](#building-your-turbolinks-application)
 - [Running JavaScript When a Page Loads](#running-javascript-when-a-page-loads)
 - [Working with Script Elements](#working-with-script-elements)
+  - [Loading Your Application’s JavaScript Bundle](#loading-your-applications-javascript-bundle)
 - [Understanding Caching](#understanding-caching)
   - [Preparing the Page to be Cached](#preparing-the-page-to-be-cached)
   - [Detecting When a Preview is Visible](#detecting-when-a-preview-is-visible)
@@ -199,11 +200,26 @@ When possible, avoid using the `turbolinks:load` event to add event listeners di
 
 Your browser automatically loads and evaluates any `<script>` elements present on the initial page load.
 
-When you navigate to a new page, Turbolinks looks for any `<script>` elements in the new page’s `<head>` that aren’t present on the current page. Then it appends them to the current `<head>` where they’re loaded and evaluated by the browser. You can use this to load additional JavaScript files on-demand.
+When you navigate to a new page, Turbolinks looks for any `<script>` elements in the new page’s `<head>` which aren’t present on the current page. Then it appends them to the current `<head>` where they’re loaded and evaluated by the browser. You can use this to load additional JavaScript files on-demand.
 
 Turbolinks evaluates `<script>` elements in a page’s `<body>` each time it renders the page. You can use inline body scripts to set up per-page JavaScript state or bootstrap client-side models. To install behavior, or to perform more complex operations when the page changes, avoid script elements and use the `turbolinks:load` event instead.
 
 Annotate `<script>` elements with `data-turbolinks-eval="false"` if you do not want Turbolinks to evaluate them after rendering. Note that this annotation will not prevent your browser from evaluating scripts on the initial page load.
+
+### Loading Your Application’s JavaScript Bundle
+
+Always make sure to load your application’s JavaScript bundle using `<script>` elements in the `<head>` of your document. Otherwise, Turbolinks will reload the bundle with every page change.
+
+```html
+<head>
+  ...
+  <script src="/application-cbd3cd4.js" defer></script>
+</head>
+```
+
+If you have traditionally placed application scripts at the end of `<body>` for performance reasons, consider using the [`<script defer>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer) attribute instead. It has [widespread browser support](https://caniuse.com/#feat=script-defer) and allows you to keep your scripts in `<head>` for Turbolinks compatibility.
+
+You should also consider configuring your asset packaging system to fingerprint each script so it has a new URL when its contents change. Then you can use the `data-turbolinks-track` attribute to force a full page reload when you deploy a new JavaScript bundle. See [Reloading When Assets Change](#reloading-when-assets-change) for information.
 
 ## Understanding Caching
 

--- a/src/turbolinks/index.coffee
+++ b/src/turbolinks/index.coffee
@@ -3,6 +3,7 @@
 #= require_self
 #= require ./helpers
 #= require ./controller
+#= require ./script_warning
 #= require ./start
 
 @Turbolinks =

--- a/src/turbolinks/script_warning.coffee
+++ b/src/turbolinks/script_warning.coffee
@@ -1,0 +1,16 @@
+do ->
+  return unless element = script = document.currentScript
+  return if script.hasAttribute("data-turbolinks-suppress-warning")
+
+  while element = element.parentNode
+    if element is document.body
+      return console.warn """
+        You are loading Turbolinks from a <script> element inside the <body> element. This is probably not what you meant to do!
+
+        Load your application’s JavaScript bundle inside the <head> element instead. <script> elements in <body> are evaluated with each page change.
+
+        For more information, see: https://github.com/turbolinks/turbolinks#working-with-script-elements
+
+        ——
+        Suppress this warning by adding a `data-turbolinks-suppress-warning` attribute to: %s
+      """, script.outerHTML


### PR DESCRIPTION
This branch shows an early warning in the console when `document.currentScript` is a child of `<body>`:

![screen shot 2018-01-04 at 8 33 43 am](https://user-images.githubusercontent.com/2603/34568967-fe558240-f12c-11e7-8bf1-9ee6ad2b2127.png)

Turbolinks is designed for application scripts to live in `<head>`, but best practices from several years ago encouraged folks to put all scripts at the end of `<body>`. That seems to trip people up fairly often.