### PR TITLE
Skip autofocusing in preview snapshots

### DIFF
--- a/src/turbolinks/snapshot_renderer.coffee
+++ b/src/turbolinks/snapshot_renderer.coffee
@@ -2,7 +2,7 @@
 #= require ./head_details
 
 class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
-  constructor: (@currentSnapshot, @newSnapshot) ->
+  constructor: (@currentSnapshot, @newSnapshot, @isPreview) ->
     @currentHeadDetails = new Turbolinks.HeadDetails @currentSnapshot.head
     @newHeadDetails = new Turbolinks.HeadDetails @newSnapshot.head
     @newBody = @newSnapshot.body
@@ -12,7 +12,7 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
       @mergeHead()
       @renderView =>
         @replaceBody()
-        @focusFirstAutofocusableElement()
+        @focusFirstAutofocusableElement() unless @isPreview
         callback()
     else
       @invalidateView()

--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -8,14 +8,14 @@ class Turbolinks.View
 
   getRootLocation: ->
     @getSnapshot().getRootLocation()
-    
+
   getSnapshot: ->
     Turbolinks.Snapshot.fromElement(@element)
 
   render: ({snapshot, error, isPreview}, callback) ->
     @markAsPreview(isPreview)
     if snapshot?
-      @renderSnapshot(snapshot, callback)
+      @renderSnapshot(snapshot, isPreview, callback)
     else
       @renderError(error, callback)
 
@@ -27,8 +27,8 @@ class Turbolinks.View
     else
       @element.removeAttribute("data-turbolinks-preview")
 
-  renderSnapshot: (snapshot, callback) ->
-    Turbolinks.SnapshotRenderer.render(@delegate, callback, @getSnapshot(), Turbolinks.Snapshot.wrap(snapshot))
+  renderSnapshot: (snapshot, isPreview, callback) ->
+    Turbolinks.SnapshotRenderer.render(@delegate, callback, @getSnapshot(), Turbolinks.Snapshot.wrap(snapshot), isPreview)
 
   renderError: (error, callback) ->
     Turbolinks.ErrorRenderer.render(@delegate, callback, error)


### PR DESCRIPTION
This is an alternate take on https://github.com/turbolinks/turbolinks/pull/292 that passes `isPreview` instead of mutating snapshots with it.

Fixes #290
Closes #292 