### PR TITLE
Add Turbolinks.setProgressBarDelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Your application can use the [`turbolinks` npm package](https://www.npmjs.com/pa
 [API Reference](#api-reference)
 - [Turbolinks.visit](#turbolinksvisit)
 - [Turbolinks.clearCache](#turbolinksclearcache)
+- [Turbolinks.setProgressBarDelay](#turbolinkssetprogressbardelay)
 - [Turbolinks.supported](#turbolinkssupported)
 - [Full List of Events](#full-list-of-events)
 
@@ -314,7 +315,7 @@ Before each render, Turbolinks matches all permanent elements by `id` and transf
 
 During Turbolinks navigation, the browser will not display its native progress indicator. Turbolinks installs a CSS-based progress bar to provide feedback while issuing a request.
 
-The progress bar is enabled by default. It appears automatically for any page that takes longer than 500ms to load.
+The progress bar is enabled by default. It appears automatically for any page that takes longer than 500ms to load. (You can change this delay with the [`Turbolinks.setProgressBarDelay`]() method.)
 
 The progress bar is a `<div>` element with the class name `turbolinks-progress-bar`. Its default styles appear first in the document and can be overridden by rules that come later.
 
@@ -427,6 +428,17 @@ Turbolinks.clearCache()
 ```
 
 Removes all entries from the Turbolinks page cache. Call this when state has changed on the server that may affect cached pages.
+
+## Turbolinks.setProgressBarDelay
+
+Usage:
+```js
+Turbolinks.setProgressBarDelay(delayInMilliseconds)
+```
+
+Sets the delay after which the [progress bar](#displaying-progress) will appear during navigation, in milliseconds. The progress bar appears after 500ms by default.
+
+Note that this method has no effect when used with the iOS or Android adapters.
 
 ## Turbolinks.supported
 

--- a/src/turbolinks/browser_adapter.coffee
+++ b/src/turbolinks/browser_adapter.coffee
@@ -3,7 +3,6 @@
 
 class Turbolinks.BrowserAdapter
   {NETWORK_FAILURE, TIMEOUT_FAILURE} = Turbolinks.HttpRequest
-  PROGRESS_BAR_DELAY = 500
 
   constructor: (@controller) ->
     @progressBar = new Turbolinks.ProgressBar
@@ -48,7 +47,7 @@ class Turbolinks.BrowserAdapter
   # Private
 
   showProgressBarAfterDelay: ->
-    @progressBarTimeout = setTimeout(@showProgressBar, PROGRESS_BAR_DELAY)
+    @progressBarTimeout = setTimeout(@showProgressBar, @controller.progressBarDelay)
 
   showProgressBar: =>
     @progressBar.show()

--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -13,6 +13,7 @@ class Turbolinks.Controller
     @scrollManager = new Turbolinks.ScrollManager this
     @restorationData = {}
     @clearCache()
+    @setProgressBarDelay(500)
 
   start: ->
     if Turbolinks.supported and not @started
@@ -52,6 +53,9 @@ class Turbolinks.Controller
       @startVisit(location, action, {restorationData})
     else
       window.location = location
+
+  setProgressBarDelay: (delay) ->
+    @progressBarDelay = delay
 
   # History
 

--- a/src/turbolinks/index.coffee
+++ b/src/turbolinks/index.coffee
@@ -17,3 +17,6 @@
 
   clearCache: ->
     Turbolinks.controller.clearCache()
+
+  setProgressBarDelay: (delay) ->
+    Turbolinks.controller.setProgressBarDelay(delay)


### PR DESCRIPTION
Based on the patch in #124, but delegates the delay to `Controller` instead of reaching into the browser adapter directly.