### PR TITLE
Support scrolling to named anchors

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -104,7 +104,7 @@ class Turbolinks.Controller
   # Scrolling
 
   scrollToAnchor: (anchor) ->
-    if element = document.getElementById(anchor)
+    if element = @view.getElementForAnchor(anchor)
       @scrollToElement(element)
     else
       @scrollToPosition(x: 0, y: 0)

--- a/src/turbolinks/snapshot.coffee
+++ b/src/turbolinks/snapshot.coffee
@@ -31,8 +31,11 @@ class Turbolinks.Snapshot
   getCacheControlValue: ->
     @getSetting("cache-control")
 
+  getElementForAnchor: (anchor) ->
+    try @body.querySelector("[id='#{anchor}'], a[name='#{anchor}']")
+
   hasAnchor: (anchor) ->
-    try @body.querySelector("[id='#{anchor}']")?
+    @getElementForAnchor(anchor)?
 
   isPreviewable: ->
     @getCacheControlValue() isnt "no-preview"

--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -9,6 +9,9 @@ class Turbolinks.View
   getRootLocation: ->
     @getSnapshot().getRootLocation()
 
+  getElementForAnchor: (anchor) ->
+    @getSnapshot().getElementForAnchor(anchor)
+
   getSnapshot: ->
     Turbolinks.Snapshot.fromElement(@element)
 

--- a/test/src/fixtures/navigation.html
+++ b/test/src/fixtures/navigation.html
@@ -14,6 +14,7 @@
       <p data-turbolinks="false"><a id="same-origin-unannotated-link-inside-false-container" href="/fixtures/one.html">Same-origin unannotated link inside data-turbolinks=false container</a></p>
       <p data-turbolinks="false"><a id="same-origin-true-link-inside-false-container" href="/fixtures/one.html" data-turbolinks="true">Same-origin data-turbolinks=true link inside data-turbolinks=false container</a></p>
       <p><a id="same-origin-anchored-link" href="/fixtures/one.html#element-id">Same-origin anchored link</a></p>
+      <p><a id="same-origin-anchored-link-named" href="/fixtures/one.html#named-anchor">Same-origin link to named anchor</a></p>
       <p><a id="cross-origin-unannotated-link" href="about:blank">Cross-origin unannotated link</a></p>
       <p><a id="same-origin-targeted-link" href="/fixtures/one.html" target="_blank">Same-origin targeted link</a></p>
       <p><a id="same-origin-download-link" href="/fixtures/one.html" download="one.html">Same-origin download link</a></p>

--- a/test/src/fixtures/one.html
+++ b/test/src/fixtures/one.html
@@ -10,6 +10,7 @@
     <h1>One</h1>
 
     <!--styles ensure that the element will be scrolled to top when navigated to via an anchored link -->
+    <a name="named-anchor"></a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
   </body>
 </html>

--- a/test/src/modules/navigation_tests.coffee
+++ b/test/src/modules/navigation_tests.coffee
@@ -48,6 +48,15 @@ navigationTest "following a same-origin anchored link", (assert, session, done) 
       assert.scrolledTo(session.element.document.getElementById('element-id'))
       done()
 
+navigationTest "following a same-origin link to named anchor", (assert, session, done) ->
+  session.clickSelector "#same-origin-anchored-link-named", (navigation) ->
+    session.waitForEvent "turbolinks:load", ->
+      assert.equal(navigation.location.pathname, "/fixtures/one.html")
+      assert.equal(navigation.location.hash, "#named-anchor")
+      assert.equal(navigation.action, "push")
+      assert.scrolledTo(session.element.document.querySelector('[name=named-anchor]'))
+      done()
+
 navigationTest "following a cross-origin unannotated link", (assert, session, done) ->
   session.clickSelector "#cross-origin-unannotated-link", (navigation) ->
     assert.equal(navigation.location, "about:blank")


### PR DESCRIPTION
Alternate take on #175.

`Turbolinks.Visit` also looks for an element matching the location's anchor [when deciding whether to use a cached version of the page](https://github.com/turbolinks/turbolinks/blob/f5f6495f650ab53d49e0e60554021b0472b299ec/src/turbolinks/visit.coffee#L50). This check should support named anchors too. This change ensures we have a single way to get the element for an anchor, for both scrolling and caching.