### PR TITLE
Add test for scrolling to named anchors

### DIFF
--- a/test/src/fixtures/navigation.html
+++ b/test/src/fixtures/navigation.html
@@ -14,6 +14,7 @@
       <p data-turbolinks="false"><a id="same-origin-unannotated-link-inside-false-container" href="/fixtures/one.html">Same-origin unannotated link inside data-turbolinks=false container</a></p>
       <p data-turbolinks="false"><a id="same-origin-true-link-inside-false-container" href="/fixtures/one.html" data-turbolinks="true">Same-origin data-turbolinks=true link inside data-turbolinks=false container</a></p>
       <p><a id="same-origin-anchored-link" href="/fixtures/one.html#element-id">Same-origin anchored link</a></p>
+      <p><a id="same-origin-anchored-link-named" href="/fixtures/one.html#named-anchor">Same-origin link to named anchor</a></p>
       <p><a id="cross-origin-unannotated-link" href="about:blank">Cross-origin unannotated link</a></p>
       <p><a id="same-origin-targeted-link" href="/fixtures/one.html" target="_blank">Same-origin targeted link</a></p>
       <p><a id="same-origin-download-link" href="/fixtures/one.html" download="one.html">Same-origin download link</a></p>

--- a/test/src/fixtures/one.html
+++ b/test/src/fixtures/one.html
@@ -10,6 +10,7 @@
     <h1>One</h1>
 
     <!--styles ensure that the element will be scrolled to top when navigated to via an anchored link -->
+    <a name="named-anchor"></a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
   </body>
 </html>

--- a/test/src/modules/navigation_tests.coffee
+++ b/test/src/modules/navigation_tests.coffee
@@ -48,6 +48,15 @@ navigationTest "following a same-origin anchored link", (assert, session, done) 
       assert.scrolledTo(session.element.document.getElementById('element-id'))
       done()
 
+navigationTest "following a same-origin link to named anchor", (assert, session, done) ->
+  session.clickSelector "#same-origin-anchored-link-named", (navigation) ->
+    session.waitForEvent "turbolinks:load", ->
+      assert.equal(navigation.location.pathname, "/fixtures/one.html")
+      assert.equal(navigation.location.hash, "#named-anchor")
+      assert.equal(navigation.action, "push")
+      assert.scrolledTo(session.element.document.querySelector('[name=named-anchor]'))
+      done()
+
 navigationTest "following a cross-origin unannotated link", (assert, session, done) ->
   session.clickSelector "#cross-origin-unannotated-link", (navigation) ->
     assert.equal(navigation.location, "about:blank")


### PR DESCRIPTION
https://github.com/turbolinks/turbolinks/pull/270 added an assertion to test whether Turbolinks scrolls to a given element. This PR uses that to test scrolling to named anchors. The base branch is `scroll-to-named-anchor`, so if merged will become part of https://github.com/turbolinks/turbolinks/pull/348