### PR TITLE
Ensure new <script>s are loaded in order when navigating

### DIFF
--- a/src/turbolinks/renderer.coffee
+++ b/src/turbolinks/renderer.coffee
@@ -19,6 +19,7 @@ class Turbolinks.Renderer
     else
       createdScriptElement = document.createElement("script")
       createdScriptElement.textContent = element.textContent
+      createdScriptElement.async = false
       copyElementAttributes(createdScriptElement, element)
       createdScriptElement
 


### PR DESCRIPTION
As noted by @kmmbvnr in https://github.com/turbolinks/turbolinks/issues/282#issuecomment-355731712, setting `async = false` doesn't load dynamically created `<script>`s synchronously, but it *does* ensure that they're loaded in order.