### PR TITLE
Increase clarity regarding redirect responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ When you visit location `/one` and the server redirects you to location `/two`, 
 
 However, Turbolinks makes requests using `XMLHttpRequest`, which transparently follows redirects. There’s no way for Turbolinks to tell whether a request resulted in a redirect without additional cooperation from the server.
 
-To work around this problem, send the `Turbolinks-Location` header in response to a visit that was redirected, and Turbolinks will replace the browser’s topmost history entry with the value you provide.
+To work around this problem, send the `Turbolinks-Location` header in response to a visit that was redirected, and Turbolinks will replace the browser’s topmost history entry with the value you provide. To be clear: It's the response the visitor was redirected to that needs the header. The response that does the redirecting doesn't need the header.
 
 The Turbolinks Rails engine sets `Turbolinks-Location` automatically when using `redirect_to` in response to a Turbolinks visit.
 


### PR DESCRIPTION
I struggled a bit with figuring this one out – I put the header on the redirecting response, but that did not work. Only after some googling and trial and error did I find out which response needs the header. Therefore, I think the documentation could be a bit clearer.

I'm not married to the exact wording, so feel free to change it as you see fit 🙂 

Thanks a lot for making Turbolinks 😄  👍  🥇 