### PR TITLE
Update gem installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Turbolinks automatically initializes itself when loaded via a standalone `<scrip
 
 Your Ruby on Rails application can use the [`turbolinks` RubyGem](https://github.com/turbolinks/turbolinks-rails) to install Turbolinks. This gem contains a Rails engine which integrates seamlessly with the Rails asset pipeline.
 
-1. Add the `turbolinks` gem, version 5, to your Gemfile: `gem 'turbolinks', '~> 5.0.0'`
+1. Add the `turbolinks` gem, version 5, to your Gemfile: `gem 'turbolinks', '~> 5.1.0'`
 2. Run `bundle install`.
 3. Add `//= require turbolinks` to your JavaScript manifest file (usually found at `app/assets/javascripts/application.js`).
 
-The gem also provides server-side support for Turbolinks redirection.
+The gem also provides server-side support for Turbolinks redirection, which can be used without the asset pipeline.
 
 ### Installation Using npm
 


### PR DESCRIPTION
The new version of the ruby gem (5.1.0) allows using turbolinks without the asset pipeline, as discussed here: https://github.com/turbolinks/turbolinks-rails/pull/18

I think it's important to update this documentation, because installing an older version without the asset pipeline throws an error.