### PR TITLE
Deferred snapshot caching

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -89,8 +89,7 @@ class Turbolinks.Controller
   # Snapshot cache
 
   getCachedSnapshotForLocation: (location) ->
-    snapshot = @cache.get(location)
-    snapshot.clone() if snapshot
+    @cache.get(location)?.clone()
 
   shouldCacheSnapshot: ->
     @view.getSnapshot().isCacheable()
@@ -99,7 +98,9 @@ class Turbolinks.Controller
     if @shouldCacheSnapshot()
       @notifyApplicationBeforeCachingSnapshot()
       snapshot = @view.getSnapshot()
-      @cache.put(@lastRenderedLocation, snapshot.clone())
+      location = @lastRenderedLocation
+      Turbolinks.defer =>
+        @cache.put(location, snapshot.clone())
 
   # Scrolling
 

--- a/src/turbolinks/head_details.coffee
+++ b/src/turbolinks/head_details.coffee
@@ -1,13 +1,16 @@
 class Turbolinks.HeadDetails
-  constructor: (@element) ->
+  @fromHeadElement: (headElement) ->
+    new this headElement?.childNodes ? []
+
+  constructor: (childNodes) ->
     @elements = {}
-    for element in @element.childNodes when element.nodeType is Node.ELEMENT_NODE
-      key = element.outerHTML
+    for node in childNodes when node.nodeType is Node.ELEMENT_NODE
+      key = node.outerHTML
       data = @elements[key] ?=
-        type: elementType(element)
-        tracked: elementIsTracked(element)
+        type: elementType(node)
+        tracked: elementIsTracked(node)
         elements: []
-      data.elements.push(element)
+      data.elements.push(node)
 
   hasElementWithKey: (key) ->
     key of @elements
@@ -33,6 +36,16 @@ class Turbolinks.HeadDetails
         provisionalElements.push(elements[1...]...)
     provisionalElements
 
+  getMetaValue: (name) ->
+    @findMetaElementByName(name)?.getAttribute("content")
+
+  findMetaElementByName: (name) ->
+    element = undefined
+    for key, {elements} of @elements
+      if elementIsMetaElementWithName(elements[0], name)
+        element = elements[0]
+    element
+
   elementType = (element) ->
     if elementIsScript(element)
       "script"
@@ -49,3 +62,7 @@ class Turbolinks.HeadDetails
   elementIsStylesheet = (element) ->
     tagName = element.tagName.toLowerCase()
     tagName is "style" or (tagName is "link" and element.getAttribute("rel") is "stylesheet")
+
+  elementIsMetaElementWithName = (element, name) ->
+    tagName = element.tagName.toLowerCase()
+    tagName is "meta" and element.getAttribute("name") is name

--- a/src/turbolinks/snapshot.coffee
+++ b/src/turbolinks/snapshot.coffee
@@ -20,10 +20,10 @@ class Turbolinks.Snapshot
     headDetails = Turbolinks.HeadDetails.fromHeadElement(headElement)
     new this headDetails, bodyElement
 
-  constructor: (@headDetails, @body) ->
+  constructor: (@headDetails, @bodyElement) ->
 
   clone: ->
-    new @constructor @headDetails, @body.cloneNode(true)
+    new @constructor @headDetails, @bodyElement.cloneNode(true)
 
   getRootLocation: ->
     root = @getSetting("root") ? "/"
@@ -33,7 +33,7 @@ class Turbolinks.Snapshot
     @getSetting("cache-control")
 
   getElementForAnchor: (anchor) ->
-    try @body.querySelector("[id='#{anchor}'], a[name='#{anchor}']")
+    try @bodyElement.querySelector("[id='#{anchor}'], a[name='#{anchor}']")
 
   hasAnchor: (anchor) ->
     @getElementForAnchor(anchor)?

--- a/src/turbolinks/snapshot.coffee
+++ b/src/turbolinks/snapshot.coffee
@@ -35,6 +35,18 @@ class Turbolinks.Snapshot
   getElementForAnchor: (anchor) ->
     try @bodyElement.querySelector("[id='#{anchor}'], a[name='#{anchor}']")
 
+  getPermanentElements: ->
+    @bodyElement.querySelectorAll("[id][data-turbolinks-permanent]")
+
+  getPermanentElementById: (id) ->
+    @bodyElement.querySelector("##{id}[data-turbolinks-permanent]")
+
+  getPermanentElementsPresentInSnapshot: (snapshot) ->
+    element for element in @getPermanentElements() when snapshot.getPermanentElementById(element.id)
+
+  findFirstAutofocusableElement: ->
+    @bodyElement.querySelector("[autofocus]")
+
   hasAnchor: (anchor) ->
     @getElementForAnchor(anchor)?
 

--- a/src/turbolinks/snapshot_renderer.coffee
+++ b/src/turbolinks/snapshot_renderer.coffee
@@ -4,7 +4,7 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
   constructor: (@currentSnapshot, @newSnapshot, @isPreview) ->
     @currentHeadDetails = @currentSnapshot.headDetails
     @newHeadDetails = @newSnapshot.headDetails
-    @newBody = @newSnapshot.body
+    @newBody = @newSnapshot.bodyElement
 
   render: (callback) ->
     if @shouldRender()

--- a/src/turbolinks/snapshot_renderer.coffee
+++ b/src/turbolinks/snapshot_renderer.coffee
@@ -1,10 +1,9 @@
 #= require ./renderer
-#= require ./head_details
 
 class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
   constructor: (@currentSnapshot, @newSnapshot, @isPreview) ->
-    @currentHeadDetails = new Turbolinks.HeadDetails @currentSnapshot.head
-    @newHeadDetails = new Turbolinks.HeadDetails @newSnapshot.head
+    @currentHeadDetails = @currentSnapshot.headDetails
+    @newHeadDetails = @newSnapshot.headDetails
     @newBody = @newSnapshot.body
 
   render: (callback) ->

--- a/src/turbolinks/snapshot_renderer.coffee
+++ b/src/turbolinks/snapshot_renderer.coffee
@@ -51,8 +51,8 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
 
   importBodyPermanentElements: ->
     for replaceableElement in @getNewBodyPermanentElements()
-      if element = @findCurrentBodyPermanentElement(replaceableElement)
-        replaceableElement.parentNode.replaceChild(element, replaceableElement)
+      if permanentElement = @findCurrentBodyPermanentElement(replaceableElement)
+        importPermanentElement(permanentElement, replaceableElement)
 
   activateBodyScriptElements: ->
     for replaceableElement in @getNewBodyScriptElements()
@@ -88,3 +88,8 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
 
   findFirstAutofocusableElement: ->
     document.body.querySelector("[autofocus]")
+
+  importPermanentElement = (permanentElement, replaceableElement) ->
+    permanentElement.parentNode.replaceChild(permanentElement.cloneNode(true), permanentElement)
+    replaceableElement.parentNode.replaceChild(permanentElement, replaceableElement)
+    permanentElement

--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -4,7 +4,7 @@
 
 class Turbolinks.View
   constructor: (@delegate) ->
-    @element = document.documentElement
+    @htmlElement = document.documentElement
 
   getRootLocation: ->
     @getSnapshot().getRootLocation()
@@ -13,7 +13,7 @@ class Turbolinks.View
     @getSnapshot().getElementForAnchor(anchor)
 
   getSnapshot: ->
-    Turbolinks.Snapshot.fromElement(@element)
+    Turbolinks.Snapshot.fromHTMLElement(@htmlElement)
 
   render: ({snapshot, error, isPreview}, callback) ->
     @markAsPreview(isPreview)
@@ -26,9 +26,9 @@ class Turbolinks.View
 
   markAsPreview: (isPreview) ->
     if isPreview
-      @element.setAttribute("data-turbolinks-preview", "")
+      @htmlElement.setAttribute("data-turbolinks-preview", "")
     else
-      @element.removeAttribute("data-turbolinks-preview")
+      @htmlElement.removeAttribute("data-turbolinks-preview")
 
   renderSnapshot: (snapshot, isPreview, callback) ->
     Turbolinks.SnapshotRenderer.render(@delegate, callback, @getSnapshot(), Turbolinks.Snapshot.wrap(snapshot), isPreview)

--- a/test/src/fixtures/permanent_element.html
+++ b/test/src/fixtures/permanent_element.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Turbolinks</title>
+    <script src="/turbolinks.js" data-turbolinks-track="reload"></script>
+  </head>
+  <body>
+    <section>
+      <h1>Permanent element</h1>
+    </section>
+    <div id="permanent" data-turbolinks-permanent>Permanent element</div>
+  </body>
+</html>

--- a/test/src/fixtures/rendering.html
+++ b/test/src/fixtures/rendering.html
@@ -16,6 +16,8 @@
       <p><a id="eval-false-script-link" href="/fixtures/eval_false_script.html">data-turbolinks-eval=false script</a></p>
       <p><a id="nonexistent-link" href="/nonexistent">Nonexistent link</a></p>
       <p><a id="visit-control-reload-link" href="/fixtures/visit_control_reload.html">Visit control: reload</a></p>
+      <p><a id="permanent-element-link" href="/fixtures/permanent_element.html">Permanent element</a></p>
     </section>
+    <div id="permanent" data-turbolinks-permanent>Rendering</div>
   </body>
 </html>

--- a/test/src/modules/rendering_tests.coffee
+++ b/test/src/modules/rendering_tests.coffee
@@ -137,6 +137,29 @@ renderingTest "preserves permanent elements", (assert, session, done) ->
         assert.equal(findPermanentElement(), permanentElement)
         done()
 
+renderingTest "before-cache event", (assert, session, done) ->
+  {body} = session.element.document
+  session.clickSelector "#same-origin-link", ->
+    session.waitForEvent "turbolinks:before-cache", ->
+      body.querySelector("h1").textContent = "Modified"
+    session.waitForEvent "turbolinks:render", ->
+      session.goBack()
+      session.waitForEvent "turbolinks:render", ->
+        assert.equal(body.querySelector("h1").textContent, "Modified")
+        done()
+
+renderingTest "mutation record as before-cache notification", (assert, session, done) ->
+  {documentElement, body} = session.element.document
+  session.clickSelector("#same-origin-link")
+  observe documentElement, childList: true, (stop, {removedNodes}) ->
+    if body in removedNodes
+      stop()
+      body.querySelector("h1").textContent = "Modified"
+      session.goBack()
+      session.waitForEvent "turbolinks:render", ->
+        assert.equal(body.querySelector("h1").textContent, "Modified")
+        done()
+
 renderingTest "error pages", (assert, session, done) ->
   session.clickSelector "#nonexistent-link", ->
     session.waitForEvent "turbolinks:render", ->
@@ -156,3 +179,10 @@ match = (element, selector) ->
   html = document.documentElement
   fn = html.matchesSelector ? html.webkitMatchesSelector ? html.msMatchesSelector ? html.mozMatchesSelector
   fn.call(element, selector)
+
+observe = (element, options, callback) ->
+  observer = new MutationObserver (records) ->
+    stop = -> observer.disconnect()
+    for record in records
+      callback(stop, record)
+  observer.observe(element, options)

--- a/test/src/modules/rendering_tests.coffee
+++ b/test/src/modules/rendering_tests.coffee
@@ -123,6 +123,20 @@ renderingTest "does not evaluate data-turbolinks-eval=false scripts", (assert, s
       assert.equal(session.element.window.bodyScriptEvaluationCount, null)
       done()
 
+renderingTest "preserves permanent elements", (assert, session, done) ->
+  permanentElement = do findPermanentElement = ->
+    session.element.document.getElementById("permanent")
+
+  assert.equal(permanentElement.textContent, "Rendering")
+  session.clickSelector "#permanent-element-link", ->
+    session.waitForEvent "turbolinks:render", ->
+      assert.equal(findPermanentElement(), permanentElement)
+      assert.equal(permanentElement.textContent, "Rendering")
+      session.goBack()
+      session.waitForEvent "turbolinks:render", ->
+        assert.equal(findPermanentElement(), permanentElement)
+        done()
+
 renderingTest "error pages", (assert, session, done) ->
   session.clickSelector "#nonexistent-link", ->
     session.waitForEvent "turbolinks:render", ->

--- a/test/src/modules/rendering_tests.coffee
+++ b/test/src/modules/rendering_tests.coffee
@@ -86,7 +86,6 @@ renderingTest "replaces provisional elements in head", (assert, session, done) -
       session.waitForEvent "turbolinks:render", ->
         finalElements = getProvisionalElements(session.element.document)
         assert.notOk(session.element.document.querySelector("meta[name=test]"))
-        assert.notDeepEqual(originalElements, finalElements)
         assert.notDeepEqual(newElements, finalElements)
         done()
 


### PR DESCRIPTION
This pull request modifies Turbolinks to save a snapshot of the previous page to its cache asynchronously _after_ rendering, which means:

* Pages display more quickly, since the call to `body.cloneNode(true)` no longer happens inside the render frame.
* Stimulus controllers can use their `disconnect()` callbacks to prepare the page for caching.

To understand what’s changed, consider the timeline of the current rendering process:
![Timeline of the current rendering process](https://user-images.githubusercontent.com/2603/40430178-260bc2ae-5e6a-11e8-8d09-1977fd498ce6.png)

The rendering process takes place inside a `requestAnimationFrame` callback, a technique which enables Turbolinks to synchronize page replacement and scroll positioning without visual flicker.

Turbolinks dispatches a `turbolinks:before-cache` event just before rendering, which allows applications to [prepare the page for caching](https://github.com/turbolinks/turbolinks#preparing-the-page-to-be-cached). Then it clones the document and saves the result to the snapshot cache. After merging `<head>` and swapping `<body>`, Turbolinks dispatches a `turbolinks:render` event.

The browser notifies any [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) instances watching for `childList` changes on the `<html>` element about the `<body>` swap in a [microtask](https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/) at the end of the animation frame. [Stimulus](https://github.com/stimulusjs/stimulus) uses a mutation observer to detect and notify controllers when their elements connect to and disconnect from the document. It’s natural to expect to be able to [“tear down” a controller’s element in a Stimulus `disconnect()` callback](https://github.com/stimulusjs/stimulus/issues/104), but under the current rendering process, any changes to the element are ignored since the callback happens after the document has been cached by Turbolinks.

![Timeline of the new rendering process with deferred snapshot caching](https://user-images.githubusercontent.com/2603/40430179-261dce2c-5e6a-11e8-8f27-7ff4d4baea32.png)

In the revised rendering process, Turbolinks defers snapshot caching using a `setTimeout` callback, moving the expensive `cloneNode()` operation outside of the animation frame.

Deferring the clone can have a significant impact on rendering performance with large pages, and informal testing with Basecamp shows a speedup of up to 67% during rendering. Additionally, by deferring caching, it’s now possible for Stimulus controllers (and other code which uses MutationObserver) to prepare elements for caching in response to mutation records.

One caveat: [permanent elements](https://github.com/turbolinks/turbolinks#persisting-elements-across-page-loads) need to be cloned “on the way out” before they move to a new `<body>`. The new rendering process handles this automatically (78d1e5d).