### PR TITLE
Set newBody property when rendering errors

### DIFF
--- a/src/turbolinks/error_renderer.coffee
+++ b/src/turbolinks/error_renderer.coffee
@@ -1,16 +1,22 @@
 #= require ./renderer
 
 class Turbolinks.ErrorRenderer extends Turbolinks.Renderer
-  constructor: (@html) ->
+  constructor: (html) ->
+    htmlElement = document.createElement("html")
+    htmlElement.innerHTML = html
+    @newHead = htmlElement.querySelector("head")
+    @newBody = htmlElement.querySelector("body")
 
   render: (callback) ->
     @renderView =>
-      @replaceDocumentHTML()
+      @replaceHeadAndBody()
       @activateBodyScriptElements()
       callback()
 
-  replaceDocumentHTML: ->
-    document.documentElement.innerHTML = @html
+  replaceHeadAndBody: ->
+    {head, body} = document
+    head.parentNode.replaceChild(@newHead, head)
+    body.parentNode.replaceChild(@newBody, body)
 
   activateBodyScriptElements: ->
     for replaceableElement in @getScriptElements()


### PR DESCRIPTION
It's expected by the super class: https://github.com/turbolinks/turbolinks/blob/7fb280ad9b66f1aa3e52f0e4db7149ab727c59c2/src/turbolinks/renderer.coffee#L8-L11

Fixes that `event.data.newBody` would be `undefined` in `turbolinks:before-render` events for error pages.