### PR TITLE
Prevent scroll position persistence when view invalidated

### DIFF
--- a/src/turbolinks/browser_adapter.coffee
+++ b/src/turbolinks/browser_adapter.coffee
@@ -57,4 +57,4 @@ class Turbolinks.BrowserAdapter
     clearTimeout(@progressBarTimeout)
 
   reload: ->
-    window.location.reload()
+    window.location.reload(true)

--- a/test/fixtures/navigation.html
+++ b/test/fixtures/navigation.html
@@ -21,6 +21,11 @@
       <p><a id="same-origin-download-link" href="/fixtures/one.html" download="one.html">Same-origin download link</a></p>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
+
+      <!--style is for testing scroll position when page is reloaded -->
+      <div style="margin-top: 200vh;">
+        <a id="page-invalidated-link" href="/fixtures/tracked_asset_change.html">Page invalidated link</a>
+      </div>
     </section>
   </body>
 </html>

--- a/test/fixtures/tracked_asset_change.html
+++ b/test/fixtures/tracked_asset_change.html
@@ -7,6 +7,7 @@
     <script src="/fixtures/test.js"></script>
   </head>
   <body>
-    <h1>Tracked asset change</h1>
+    <!--style is for testing scroll position when reloaded -->
+    <h1 style="height: 200vh">Tracked asset change</h1>
   </body>
 </html>

--- a/test/lib/browser_test_case.ts
+++ b/test/lib/browser_test_case.ts
@@ -15,6 +15,10 @@ export class BrowserTestCase extends InternTestCase {
     return this.remote.goForward()
   }
 
+  async refresh(): Promise<void> {
+    return this.remote.refresh()
+  }
+
   async hasSelector(selector: string) {
     return (await this.remote.findAllByCssSelector(selector)).length > 0
   }
@@ -36,6 +40,10 @@ export class BrowserTestCase extends InternTestCase {
     const { y: elementY } = await this.remote.findByCssSelector(selector).getPosition()
     const offset = pageY - elementY
     return offset > -1 && offset < 1
+  }
+
+  async scrollToSelector(selector: string): Promise<void> {
+    return this.remote.moveMouseTo(await this.remote.findByCssSelector(selector))
   }
 
   async evaluate<T>(callback: () => T): Promise<T> {

--- a/test/suites/navigation_tests.ts
+++ b/test/suites/navigation_tests.ts
@@ -99,6 +99,22 @@ class NavigationTests extends TurbolinksTestCase {
     this.assert.equal(await this.visitAction, "load")
   }
 
+  async "test following a link to a page which reloads"() {
+    await this.scrollToSelector("#page-invalidated-link")
+    this.clickSelector("#page-invalidated-link")
+    await this.nextBody
+    this.assert.equal(await this.pathname, "/fixtures/tracked_asset_change.html")
+    this.assert.equal(await this.visitAction, "load")
+    this.assert.deepEqual(await this.scrollPosition, { x: 0, y: 0 })
+  }
+
+  async "test refreshing a scrolled page"() {
+    await this.scrollToSelector("#page-invalidated-link")
+    const positionBeforeRefresh = await this.scrollPosition
+    await this.refresh()
+    this.assert.deepEqual(await this.scrollPosition, positionBeforeRefresh)
+  }
+
   async "test clicking the back button"() {
     this.clickSelector("#same-origin-unannotated-link")
     await this.nextBody


### PR DESCRIPTION
A simpler fix for #181 /#248 (I thought I tested this when working on #420, but obviously not well enough!)

As is discussed in #181, when a view is invalidated the scroll position is persisted when the page is refreshed. This results in an odd experience, particularly when navigating between long pages with different assets.

To fix this, the `window.location.reload` `forceReload` flag is set to `true` to scroll to the top on reload:

>  Besides caching behaviour the forcedReload flag also impacts how some browsers handle the scroll position: ordinary reload tries to restore the scroll position after reloading the page, while in forced mode (when parameter is set to true) the new DOM gets loaded with scrollTop == 0.
> https://developer.mozilla.org/en-US/docs/Web/API/Location/reload

I'm not sure what "some browsers" means, but it has the desired effect in ~Safari~, ~Chrome~, and Firefox on macOS.