### PR TITLE
fix unexpected scroll behavior when visit page has meta head with reload

### DIFF
--- a/src/turbolinks/browser_adapter.coffee
+++ b/src/turbolinks/browser_adapter.coffee
@@ -57,4 +57,4 @@ class Turbolinks.BrowserAdapter
     clearTimeout(@progressBarTimeout)
 
   reload: ->
-    window.location.reload()
+    window.location.href = window.location.href


### PR DESCRIPTION
There is an unexpect scroll behavior:

I have two kinds of pages with different layout( using ruby on rails ):  agent pages and visit pages.

agent pages layout like this:

```
meta name="turbolinks-cache-control" content="no-cache"
= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
= javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
```

visit pages layout like this:

```
meta name="turbolinks-cache-control" content="no-cache"
= stylesheet_link_tag 'pages', media: 'all', 'data-turbolinks-track': 'reload'
= javascript_include_tag 'pages', 'data-turbolinks-track': 'reload'
```

when user click link that will goto visit page from the bottom of agent page, they will find the new visit page scroll to bottom unexpectedly.

After some research, I found `window.location.reload()` will cause page scroll  the "right" place automatically. But it should not be the right behavior at the case above.

So we can replace `window.location.reload()` with `window.location.href = window.location.href`, fix the bug.

Here is a risk for this modify: 
https://stackoverflow.com/questions/2405117/difference-between-window-location-href-window-location-href-and-window-location