### PR TITLE
Prevent autoplay elements playing in the background when cloned to cache

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -97,7 +97,7 @@ class Turbolinks.Controller
   cacheSnapshot: ->
     if @shouldCacheSnapshot()
       @notifyApplicationBeforeCachingSnapshot()
-      snapshot = @view.getSnapshot()
+      snapshot = @view.getSnapshotForCache()
       location = @lastRenderedLocation
       Turbolinks.defer =>
         @cache.put(location, snapshot.clone())

--- a/src/turbolinks/snapshot.coffee
+++ b/src/turbolinks/snapshot.coffee
@@ -20,10 +20,11 @@ class Turbolinks.Snapshot
     headDetails = Turbolinks.HeadDetails.fromHeadElement(headElement)
     new this headDetails, bodyElement
 
-  constructor: (@headDetails, @bodyElement) ->
+  constructor: (@headDetails, @bodyElement, options = {}) ->
+    @autoplayElementIds = options.autoplayElementIds || []
 
   clone: ->
-    new @constructor @headDetails, @bodyElement.cloneNode(true)
+    new @constructor @headDetails, @bodyElement.cloneNode(true), { @autoplayElementIds }
 
   getRootLocation: ->
     root = @getSetting("root") ? "/"
@@ -35,6 +36,9 @@ class Turbolinks.Snapshot
   getElementForAnchor: (anchor) ->
     try @bodyElement.querySelector("[id='#{anchor}'], a[name='#{anchor}']")
 
+  getMediaElementById: (id) ->
+    @bodyElement.querySelector("audio[id='#{id}'], video[id='#{id}']")
+
   getPermanentElements: ->
     @bodyElement.querySelectorAll("[id][data-turbolinks-permanent]")
 
@@ -43,6 +47,14 @@ class Turbolinks.Snapshot
 
   getPermanentElementsPresentInSnapshot: (snapshot) ->
     element for element in @getPermanentElements() when snapshot.getPermanentElementById(element.id)
+
+  getAutoplayElements: ->
+    @bodyElement.querySelectorAll("audio[id][autoplay], video[id][autoplay]")
+
+  prepareAutoplayElementsForCloning: ->
+    for element in @getAutoplayElements()
+      @autoplayElementIds.push(element.id)
+      element.removeAttribute('autoplay')
 
   findFirstAutofocusableElement: ->
     @bodyElement.querySelector("[autofocus]")

--- a/src/turbolinks/snapshot_renderer.coffee
+++ b/src/turbolinks/snapshot_renderer.coffee
@@ -26,6 +26,7 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
   replaceBody: ->
     placeholders = @relocateCurrentBodyPermanentElements()
     @activateNewBodyScriptElements()
+    @restoreAutoplayAttributes() unless @isPreview
     @assignNewBody()
     @replacePlaceholderElementsWithClonedPermanentElements(placeholders)
 
@@ -63,6 +64,10 @@ class Turbolinks.SnapshotRenderer extends Turbolinks.Renderer
     for { element, permanentElement } in placeholders
       clonedElement = permanentElement.cloneNode(true)
       replaceElementWithElement(element, clonedElement)
+
+  restoreAutoplayAttributes: ->
+    for id in @newSnapshot.autoplayElementIds
+      @newSnapshot.getMediaElementById(id).setAttribute("autoplay", "")
 
   activateNewBodyScriptElements: ->
     for inertScriptElement in @getNewBodyScriptElements()

--- a/src/turbolinks/view.coffee
+++ b/src/turbolinks/view.coffee
@@ -15,6 +15,11 @@ class Turbolinks.View
   getSnapshot: ->
     Turbolinks.Snapshot.fromHTMLElement(@htmlElement)
 
+  getSnapshotForCache: ->
+    snapshot = Turbolinks.Snapshot.fromHTMLElement(@htmlElement)
+    snapshot.prepareAutoplayElementsForCloning()
+    snapshot
+
   render: ({snapshot, error, isPreview}, callback) ->
     @markAsPreview(isPreview)
     if snapshot?


### PR DESCRIPTION
## The Problem

`autoplay` `<audio>` and `<video>` elements automatically start playing when they are cloned, even if they are not present in the document body. Turbolinks clones the body when caching meaning these elements are susceptible to this quirk. This can result in uncontrollable audio and video elements playing in the background. (As one StackOverflow questioner put it, "Fun at first, nightmare after 5 seconds." https://stackoverflow.com/q/50881424/783009)

## The Solution

This pull request augments the caching flow, by storing a list of autoplay element IDs on the snapshot just before cloning. Then when restoring from cache, the snapshot renderer gets the autoplay elements from the list of IDs and restores the autoplay attribute on each of them. In a similar way to the `data-turbolinks-permanent` feature, this requires that autoplay elements have an ID.

## Alternative Solutions

In many cases, autoplaying media elements are annoying, particularly those with sound. This has been recognised by [Safari](https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/) and [Chrome](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes) as they have updated their polcies to prevent non-muted autoplay elements from starting automatically:

> These changes provide users the ability to browse the web with fewer distractions, particularly in the form of relief from websites that auto-play with sound.
> https://webkit.org/blog/7734/auto-play-policy-changes-for-macos/

With this in mind, we could simply suggest that people not use `autoplay`. However, this might frustrate those with legitimate use cases (e.g. a video hosting service).

Alternatively, there is a workaround which implements very similar behaviour as in this pull request:

```js
;(function () {
  var each = Array.prototype.forEach
  var autoplayIds = []

  document.addEventListener('turbolinks:before-cache', function () {
    var autoplayElements = document.querySelectorAll('[autoplay]')
    each.call(autoplayElements, function (element) {
      if (!element.id) throw 'autoplay elements need an ID attribute'
      autoplayIds.push(element.id)
      element.removeAttribute('autoplay')
    })
  })

  document.addEventListener('turbolinks:before-render', function (event) {
    autoplayIds = autoplayIds.reduce(function (ids, id) {
      var autoplay = event.data.newBody.querySelector('#' + id)
      if (autoplay) autoplay.setAttribute('autoplay', true)
      else ids.push(id)
      return ids
    }, [])
  })
})()
```