### PR TITLE
Add action property to turbolinks:visit event (2)

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -172,8 +172,8 @@ class Turbolinks.Controller
   notifyApplicationBeforeVisitingLocation: (location) ->
     Turbolinks.dispatch("turbolinks:before-visit", data: { url: location.absoluteURL }, cancelable: true)
 
-  notifyApplicationAfterVisitingLocation: (location) ->
-    Turbolinks.dispatch("turbolinks:visit", data: { url: location.absoluteURL })
+  notifyApplicationAfterVisitingLocation: (location, action) ->
+    Turbolinks.dispatch("turbolinks:visit", data: { url: location.absoluteURL, action: action })
 
   notifyApplicationBeforeCachingSnapshot: ->
     Turbolinks.dispatch("turbolinks:before-cache")
@@ -193,7 +193,7 @@ class Turbolinks.Controller
     @currentVisit?.cancel()
     @currentVisit = @createVisit(location, action, properties)
     @currentVisit.start()
-    @notifyApplicationAfterVisitingLocation(location)
+    @notifyApplicationAfterVisitingLocation(location, action)
 
   createVisit: (location, action, {restorationIdentifier, restorationData, historyChanged} = {}) ->
     visit = new Turbolinks.Visit this, location, action

--- a/test/suites/visit_tests.ts
+++ b/test/suites/visit_tests.ts
@@ -16,8 +16,9 @@ export class VisitTests extends TurbolinksTestCase {
     const { url: urlFromBeforeVisitEvent } = await this.nextEventNamed("turbolinks:before-visit")
     this.assert.equal(urlFromBeforeVisitEvent, urlAfterVisit)
 
-    const { url: urlFromVisitEvent } = await this.nextEventNamed("turbolinks:visit")
+    const { url: urlFromVisitEvent, action: actionFromVisitEvent } = await this.nextEventNamed("turbolinks:visit")
     this.assert.equal(urlFromVisitEvent, urlAfterVisit)
+    this.assert.equal(actionFromVisitEvent, 'advance')
   }
 
   async "test programmatically visiting a cross-origin location falls back to window.location"() {


### PR DESCRIPTION
[updated #425 with merge from feature branch instead of master]

This pull request passes the action property to the turbolinks:visit event.

We were in need of this because big parts of our app is constructed by javascript (VueJS). When navigating back it takes a 'tick' before the actual page is rendered causing the turbolinks scroll-restore not to work.

By detecting the 'restore' action, we can manually hook in and restore the scroll ourselves after Vue has rendered the page.

Fixes #135