### PR TITLE
Fix inconsistent restoration id lifecycle between browser + ios vs android

### DIFF
--- a/src/turbolinks/controller.coffee
+++ b/src/turbolinks/controller.coffee
@@ -50,7 +50,7 @@ class Turbolinks.Controller
   startVisitToLocationWithAction: (location, action, restorationIdentifier) ->
     if Turbolinks.supported
       restorationData = @getRestorationDataForIdentifier(restorationIdentifier)
-      @startVisit(location, action, {restorationData})
+      @startVisit(location, action, {restorationIdentifier, restorationData})
     else
       window.location = location
 


### PR DESCRIPTION
**Background**

When using `startVisitToLocationWithAction()` for a restoration visit, it correctly fetches the restoration data. However as it doesn't pass on the id to `startVisit()` it issues a new restoration id.

This causes inconsistency in conjunction with the android library as it relies on this method for restoration visits. Both the browser + iOS adapter reverts to the original restoration id whereas the android library will issue a new id on restoration visits.

**Fix**

Pass on the original restoration id to `startVisit()`. This is how `historyPoppedToLocationWithRestorationIdentifier()` works too.