### PR TITLE
Allow preventDefault() on "turbolinks:request-end" events

### DIFF
--- a/src/http_request.ts
+++ b/src/http_request.ts
@@ -100,7 +100,7 @@ export class HttpRequest {
   }
 
   notifyApplicationAfterRequestEnd() {
-    dispatch("turbolinks:request-end", { data: { url: this.url, xhr: this.xhr } })
+    return dispatch("turbolinks:request-end", { data: { url: this.url, xhr: this.xhr } })
   }
 
   // Private
@@ -123,8 +123,10 @@ export class HttpRequest {
 
   endRequest(callback: (xhr: XMLHttpRequest) => void = () => {}) {
     if (this.xhr) {
-      this.notifyApplicationAfterRequestEnd()
-      callback(this.xhr)
+      const event = this.notifyApplicationAfterRequestEnd()
+      if (!event.defaultPrevented) {
+        callback(this.xhr)
+      }
       this.destroy()
     }
   }


### PR DESCRIPTION
This provides a way to cancel Turbolinks requests after the response is received, but before Turbolinks handles the response. A good example might include allowing JSON responses if you're on a page that supports client-side rendering. This is inspired, in part, by [a recent article outlining server-side apps that use client-side rendering](https://reinink.ca/articles/server-side-apps-with-client-side-rendering).

```javascript
document.addEventListener('turbolinks:request-start', function(event) {
  if ('renderApp' in window) {
    // Our client-rendered app is booted, so tell Turbolinks to accept JSON responses
    event.data.xhr.setRequestHeader('Accept', "text/html, application/xhtml+xml, application/json");
  }
});

document.addEventListener('turbolinks:request-end', function(event) {
  const xhr = event.data.xhr;
  if (xhr.getResponseHeader('Content-Type').includes('application/json')) {
    // We got JSON back, so stop Turbolinks from handling, and pass the data to our app instead
    event.preventDefault();
    const ok = xhr.status >= 200 && xhr.status < 300;
    window.renderApp(ok ? JSON.parse(xhr.responseText) : { error: 'Error loading response.', xhr });
  }
});
```