### PR TITLE
Fix broken link to dist/turbolinks.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ $ yarn install
 $ yarn build
 ```
 
-Include the resulting [`dist/turbolinks.js`](dist/turbolinks.js) file in your application’s JavaScript bundle.
+Include the resulting `dist/turbolinks.js` file in your application’s JavaScript bundle.
 
 ## Running Tests
 


### PR DESCRIPTION
Since https://github.com/turbolinks/turbolinks/commit/866a29c861b0e0e0625a06189a49e29abd7a344a, [`dist` is ignored](https://github.com/turbolinks/turbolinks/blob/866a29c861b0e0e0625a06189a49e29abd7a344a/.gitignore#L1). This PR fixes the broken link to `dist/turbolinks.js` by unlinking it.