### PR TITLE
Fix <script async> navigation

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -145,8 +145,8 @@ export class Controller {
     if (this.shouldCacheSnapshot()) {
       this.notifyApplicationBeforeCachingSnapshot()
       const snapshot = this.view.getSnapshot()
-      const location = this.lastRenderedLocation
-      defer(() => this.cache.put(location!, snapshot.clone()))
+      const location = this.lastRenderedLocation || Location.currentLocation
+      defer(() => this.cache.put(location, snapshot.clone()))
     }
   }
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -95,7 +95,7 @@ export class Controller {
   // History
 
   startHistory() {
-    this.location = Location.wrap(window.location.toString())
+    this.location = Location.currentLocation
     this.restorationIdentifier = uuid()
     this.history.start()
     this.history.replace(this.location, this.restorationIdentifier)

--- a/src/history.ts
+++ b/src/history.ts
@@ -46,7 +46,7 @@ export class History {
     if (this.shouldHandlePopState()) {
       const { turbolinks } = event.state
       if (turbolinks) {
-        const location = Location.wrap(window.location.toString())
+        const location = Location.currentLocation
         const { restorationIdentifier } = turbolinks
         this.delegate.historyPoppedToLocationWithRestorationIdentifier(location, restorationIdentifier)
       }

--- a/src/location.ts
+++ b/src/location.ts
@@ -1,6 +1,10 @@
 export type Locatable = Location | string
 
 export class Location {
+  static get currentLocation() {
+    return this.wrap(window.location.toString())
+  }
+
   static wrap(locatable: Locatable): Location
   static wrap(locatable?: Locatable | null): Location | undefined
   static wrap(locatable: Locatable) {

--- a/src/tests/async_script_tests.ts
+++ b/src/tests/async_script_tests.ts
@@ -1,0 +1,20 @@
+import { TurbolinksTestCase } from "./helpers/turbolinks_test_case"
+
+export class AsyncScriptTests extends TurbolinksTestCase {
+  async setup() {
+    await this.goToLocation("/fixtures/async_script.html")
+  }
+
+  async "test does not emit turbolinks:load when loaded asynchronously after DOMContentLoaded"() {
+    const events = await this.eventLogChannel.read()
+    this.assert.deepEqual(events, [])
+  }
+
+  async "test following a link when loaded asynchronously after DOMContentLoaded"() {
+    this.clickSelector("#async-link")
+    await this.nextBody
+    this.assert.equal(await this.visitAction, "advance")
+  }
+}
+
+AsyncScriptTests.registerSuite()

--- a/src/tests/fixtures/async_script.html
+++ b/src/tests/fixtures/async_script.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Turbolinks</title>
+    <script src="/fixtures/test.js"></script>
+    <script>
+      addEventListener("DOMContentLoaded", function() {
+        setTimeout(function() {
+          var script = document.createElement("script")
+          script.src = "/fixtures/turbolinks.js"
+          script.setAttribute("async", "")
+          document.head.appendChild(script)
+        }, 1)
+      })
+    </script>
+  </head>
+  <body>
+    <section>
+      <h1>Async script</h1>
+      <p><a href="async_script_2.html" id="async-link">Async script 2</a></p>
+    </section>
+  </body>
+</html>

--- a/src/tests/fixtures/async_script_2.html
+++ b/src/tests/fixtures/async_script_2.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Turbolinks</title>
+    <script src="/fixtures/test.js"></script>
+    <script src="/fixtures/turbolinks.js" async></script>
+  </head>
+  <body>
+    <section>
+      <h1>Async script 2</h1>
+    </section>
+  </body>
+</html>

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,3 +1,4 @@
+export * from "./async_script_tests"
 export * from "./navigation_tests"
 export * from "./rendering_tests"
 export * from "./visit_tests"


### PR DESCRIPTION
This branch fixes [navigation when Turbolinks is loaded with a `<script async>` tag (#447)](#447), introduced with the TypeScript port.

(TypeScript made it possible to remove extraneous defensive calls to `Location.wrap(...)` from the CoffeeScript codebase. In one spot, the old code [passed a location variable to Cache#put which might possibly be `undefined`](https://github.com/turbolinks/turbolinks/blob/c340c42e2ece8c057aec611074971462a6e76c71/src/turbolinks/controller.coffee#L101-L103); TypeScript told me about it during the port, but I chose to [ignore it with a non-null assertion](https://github.com/turbolinks/turbolinks/blob/2f7cd3247f28152458e5f45ff281d8ec7b1f8f47/src/controller.ts#L149). Of course, it turns out I was misremembering how the Controller#pageLoaded method works when Turbolinks is [loaded asynchronously after DOMContentLoaded](#274), and TypeScript was warning me that my assumptions were wrong—because we didn’t have any tests for that behavior. So [now we do](https://github.com/turbolinks/turbolinks/commit/f2c40b786399f8c80f700d282308e8e16248f4fc)!)