### PR TITLE
Force a full page load when receiving a non-HTML response

### DIFF
--- a/src/browser_adapter.ts
+++ b/src/browser_adapter.ts
@@ -49,6 +49,7 @@ export class BrowserAdapter implements Adapter {
     switch (statusCode) {
       case SystemStatusCode.networkFailure:
       case SystemStatusCode.timeoutFailure:
+      case SystemStatusCode.contentTypeMismatch:
         return this.reload()
       default:
         return visit.loadResponse()

--- a/src/tests/fixtures/svg
+++ b/src/tests/fixtures/svg
@@ -1,0 +1,1 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg"><g></g></svg>


### PR DESCRIPTION
Avoid rendering responses without an HTML content type header.