### PR TITLE
Adds Turbolinks.setRootSelector feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The npm package alone does not provide server-side support for Turbolinks redire
 - [Reloading When Assets Change](#reloading-when-assets-change)
 - [Ensuring Specific Pages Trigger a Full Reload](#ensuring-specific-pages-trigger-a-full-reload)
 - [Setting a Root Location](#setting-a-root-location)
+- [Changing the Root Replacement Element from `<body>`](#changing-the-root-replacement-element-from-body)
 - [Following Redirects](#following-redirects)
 - [Redirecting After a Form Submission](#redirecting-after-a-form-submission)
 - [Setting Custom HTTP Headers](#setting-custom-http-headers)
@@ -414,6 +415,33 @@ Include a `<meta name="turbolinks-root">` element in your pages’ `<head>` to s
   <meta name="turbolinks-root" content="/app">
 </head>
 ```
+
+## Changing the Root Replacement Element from `<body>`
+
+By default, Turbolinks replaces the entire body on each render.  This is the best approach for the vast majority of cases, but it can cause problems, particularly with external scripts that setup an iFrame sitting at bottom of the body tag.
+
+You can change this behaviour with the `setRootSelector` function.
+
+```javascript
+  Turbolinks.setRootSelector('#my-root')
+```
+
+```html
+  ...
+  <body>
+    <div id="my-root">
+      ...
+    </div>
+
+    <div>This won't be replaced</div>
+
+    <iframe></iframe><!-- nor will this -->
+  </body>
+```
+
+If the specified element can't be found, Turbolinks falls back to replacing the entire body.
+
+CAUTION, If you set this option, particularly for iFrame persistence, then you will have to manage the elements sitting outside the turbolinks replacement root yourself.
 
 ## Following Redirects
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -9,6 +9,7 @@ import { Action, Position, isAction } from "./types"
 import { closest, defer, dispatch, uuid } from "./util"
 import { RenderOptions, View } from "./view"
 import { Visit } from "./visit"
+import { RootSelector } from "./root_selector"
 
 export type RestorationData = { scrollPosition?: Position }
 export type RestorationDataMap = { [uuid: string]: RestorationData }
@@ -35,6 +36,7 @@ export class Controller {
   lastRenderedLocation?: Location
   location!: Location
   progressBarDelay = 500
+  rootSelector: RootSelector
   restorationIdentifier!: string
   started = false
 
@@ -90,6 +92,10 @@ export class Controller {
 
   setProgressBarDelay(delay: number) {
     this.progressBarDelay = delay
+  }
+
+  setRootSelector(rootSelector: RootSelector) {
+    this.rootSelector = rootSelector
   }
 
   // History
@@ -179,6 +185,7 @@ export class Controller {
   // View
 
   render(options: Partial<RenderOptions>, callback: RenderCallback) {
+    if (this.rootSelector) options = {...options, rootSelector: this.rootSelector}
     this.view.render(options, callback)
   }
 

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,5 +1,7 @@
 import { Controller, VisitOptions } from "./controller"
 import { Locatable } from "./location"
+import { RootSelector } from "./root_selector"
+
 
 const controller = new Controller
 
@@ -20,6 +22,10 @@ export default {
 
   setProgressBarDelay(delay: number) {
     controller.setProgressBarDelay(delay)
+  },
+
+  setRootSelector(selector: RootSelector) {
+    controller.setRootSelector(selector)
   },
 
   start() {

--- a/src/root_selector.ts
+++ b/src/root_selector.ts
@@ -1,0 +1,15 @@
+export type RootSelector = string | undefined
+
+export function assignBody(newBody: HTMLBodyElement, rootSelector: RootSelector) {
+  if (rootSelector) {
+    const oldRoot = document.body.querySelector(rootSelector)
+    const newRoot = newBody.querySelector(rootSelector)
+
+    if (oldRoot && newRoot) {
+      const parent = oldRoot.parentElement
+      if (parent) return parent.replaceChild(newRoot, oldRoot)
+    }
+  }
+
+  document.body = newBody
+}

--- a/src/snapshot_renderer.ts
+++ b/src/snapshot_renderer.ts
@@ -1,6 +1,7 @@
 import { HeadDetails } from "./head_details"
 import { RenderCallback, RenderDelegate, Renderer } from "./renderer"
 import { Snapshot } from "./snapshot"
+import { RootSelector, assignBody } from "./root_selector"
 import { array } from "./util"
 
 export { RenderCallback, RenderDelegate } from "./renderer"
@@ -17,12 +18,13 @@ export class SnapshotRenderer extends Renderer {
   readonly newHeadDetails: HeadDetails
   readonly newBody: HTMLBodyElement
   readonly isPreview: boolean
+  readonly rootSelector: RootSelector
 
-  static render(delegate: RenderDelegate, callback: RenderCallback, currentSnapshot: Snapshot, newSnapshot: Snapshot, isPreview: boolean) {
-    return new this(delegate, currentSnapshot, newSnapshot, isPreview).render(callback)
+  static render(delegate: RenderDelegate, callback: RenderCallback, currentSnapshot: Snapshot, newSnapshot: Snapshot, isPreview: boolean, rootSelector: RootSelector) {
+    return new this(delegate, currentSnapshot, newSnapshot, isPreview, rootSelector).render(callback)
   }
 
-  constructor(delegate: RenderDelegate, currentSnapshot: Snapshot, newSnapshot: Snapshot, isPreview: boolean) {
+  constructor(delegate: RenderDelegate, currentSnapshot: Snapshot, newSnapshot: Snapshot, isPreview: boolean, rootSelector: RootSelector) {
     super()
     this.delegate = delegate
     this.currentSnapshot = currentSnapshot
@@ -31,6 +33,7 @@ export class SnapshotRenderer extends Renderer {
     this.newHeadDetails = newSnapshot.headDetails
     this.newBody = newSnapshot.bodyElement
     this.isPreview = isPreview
+    this.rootSelector = rootSelector
   }
 
   render(callback: RenderCallback) {
@@ -108,6 +111,10 @@ export class SnapshotRenderer extends Renderer {
     }, [] as Placeholder[])
   }
 
+  assignNewBody() {
+    assignBody(this.newBody, this.rootSelector)
+  }
+
   replacePlaceholderElementsWithClonedPermanentElements(placeholders: Placeholder[]) {
     for (const { element, permanentElement } of placeholders) {
       const clonedElement = permanentElement.cloneNode(true)
@@ -120,10 +127,6 @@ export class SnapshotRenderer extends Renderer {
       const activatedScriptElement = this.createScriptElement(inertScriptElement)
       replaceElementWithElement(inertScriptElement, activatedScriptElement)
     }
-  }
-
-  assignNewBody() {
-    replaceElementWithElement(document.body, this.newBody)
   }
 
   focusFirstAutofocusableElement() {

--- a/src/tests/fixtures/custom_root_selector.html
+++ b/src/tests/fixtures/custom_root_selector.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Custom root selector</title>
+    <script src="/fixtures/turbolinks.js" data-turbolinks-track="reload"></script>
+    <script src="/fixtures/test.js"></script>
+    <script>
+      Turbolinks.setRootSelector('[data-turbolinks-root]');
+    </script>
+  </head>
+  <body>
+    <main data-turbolinks-root>
+      <section>
+        <h1>Custom root selector</h1>
+        <p><a id="custom-root-selector-link-2" href="/fixtures/custom_root_selector_2.html">Custom root selector 2</a></p>
+        <p><a id="rendering-link" href="/fixtures/rendering.html">back to rendering</a></p>
+      </section>
+    </main>
+
+    <footer>
+      <h2>Not replaced</h2>
+      <p>rendered by: <span id="rendered-by">custom_root_selector.html</span></p>
+    </footer>
+  </body>
+</html>

--- a/src/tests/fixtures/custom_root_selector_2.html
+++ b/src/tests/fixtures/custom_root_selector_2.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Custom root selector 2</title>
+    <script src="/fixtures/turbolinks.js" data-turbolinks-track="reload"></script>
+    <script src="/fixtures/test.js"></script>
+    <script>
+      Turbolinks.setRootSelector('[data-turbolinks-root]');
+    </script>
+  </head>
+  <body>
+    <main data-turbolinks-root>
+      <section>
+        <h1>Custom root selector 2</h1>
+        <p><a id="custom-root-selector-link" href="/fixtures/custom_root_selector.html">Custom root selector</a></p>
+      </section>
+    </main>
+
+    <footer>
+      <h2>Not replaced</h2>
+      <p>rendered by: <span id="rendered-by">custom_root_selector_2.html</span></p>
+    </footer>
+  </body>
+</html>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -18,6 +18,7 @@
       <p><a id="nonexistent-link" href="/nonexistent">Nonexistent link</a></p>
       <p><a id="visit-control-reload-link" href="/fixtures/visit_control_reload.html">Visit control: reload</a></p>
       <p><a id="permanent-element-link" href="/fixtures/permanent_element.html">Permanent element</a></p>
+      <p><a id="custom-root-selector-link" href="/fixtures/custom_root_selector.html">Custom root selector</a></p>
     </section>
     <div id="permanent" data-turbolinks-permanent>Rendering</div>
   </body>

--- a/src/tests/rendering_tests.ts
+++ b/src/tests/rendering_tests.ts
@@ -142,6 +142,47 @@ export class RenderingTests extends TurbolinksTestCase {
     this.assert(await body.getVisibleText(), "Modified")
   }
 
+   async "test replaces entire body when nav from normal => custom root"() {
+    const lastBodyId = (await this.body).elementId
+
+    this.clickSelector("#custom-root-selector-link")
+    await this.nextEventNamed('turbolinks:load')
+
+    const thisBodyId = (await this.body).elementId
+    this.assert.notEqual(lastBodyId, thisBodyId)
+  }
+
+  async "test replaces entire body when nav from custom root => normal"() {
+    await this.goToLocation("/fixtures/custom_root_selector.html")
+
+    const lastBodyId = (await this.body).elementId
+
+    this.clickSelector("#rendering-link")
+    await this.nextEventNamed('turbolinks:load')
+
+    const thisBodyId = (await this.body).elementId
+    this.assert.notEqual(lastBodyId, thisBodyId)
+  }
+
+   async "test replaces only custom root with custom root specified throughout"() {
+    await this.goToLocation("/fixtures/custom_root_selector.html")
+
+    const lastBodyId  = (await this.body).elementId
+    const lastOutside = await (await this.querySelector('#rendered-by')).getVisibleText()
+    const lastInside  = await (await this.querySelector('h1')).getVisibleText()
+
+    this.clickSelector("#custom-root-selector-link-2")
+    await this.nextEventNamed('turbolinks:load')
+
+    const thisBodyId  = (await this.body).elementId
+    const thisOutside = await (await this.querySelector('#rendered-by')).getVisibleText()
+    const thisInside  = await (await this.querySelector('h1')).getVisibleText()
+
+    this.assert.equal(lastBodyId, thisBodyId)
+    this.assert.notEqual(lastInside, thisInside)
+    this.assert.equal(lastOutside, thisOutside)
+  }
+
   async "test error pages"() {
     this.clickSelector("#nonexistent-link")
     const body = await this.nextBody

--- a/src/view.ts
+++ b/src/view.ts
@@ -2,8 +2,9 @@ import { ErrorRenderer } from "./error_renderer"
 import { Location } from "./location"
 import { Snapshot } from "./snapshot"
 import { RenderCallback, RenderDelegate, SnapshotRenderer } from "./snapshot_renderer"
+import { RootSelector } from "./root_selector"
 
-export type RenderOptions = { snapshot: Snapshot, error: string, isPreview: boolean }
+export type RenderOptions = { snapshot: Snapshot, error: string, isPreview: boolean, rootSelector: RootSelector }
 
 export class View {
   readonly delegate: RenderDelegate
@@ -25,10 +26,10 @@ export class View {
     return Snapshot.fromHTMLElement(this.htmlElement)
   }
 
-  render({ snapshot, error, isPreview }: Partial<RenderOptions>, callback: RenderCallback) {
+  render({ snapshot, error, isPreview, rootSelector}: Partial<RenderOptions>, callback: RenderCallback) {
     this.markAsPreview(isPreview)
     if (snapshot) {
-      this.renderSnapshot(snapshot, isPreview, callback)
+      this.renderSnapshot(snapshot, isPreview, callback, rootSelector)
     } else {
       this.renderError(error, callback)
     }
@@ -44,8 +45,8 @@ export class View {
     }
   }
 
-  renderSnapshot(snapshot: Snapshot, isPreview: boolean | undefined, callback: RenderCallback) {
-    SnapshotRenderer.render(this.delegate, callback, this.getSnapshot(), snapshot, isPreview || false)
+  renderSnapshot(snapshot: Snapshot, isPreview: boolean | undefined, callback: RenderCallback, rootSelector: RootSelector) {
+    SnapshotRenderer.render(this.delegate, callback, this.getSnapshot(), snapshot, isPreview || false, rootSelector)
   }
 
   renderError(error: string | undefined, callback: RenderCallback) {


### PR DESCRIPTION
Based on @ahaurw01 data-turbolinks-root work [#400] [#401]
Updated for the Typescript rewrite, with documentation.
Rewritten as a configuration option, so that it is opt-in, and slightly more performant than always querying for a [data-turbolinks-root] selector.