### PR TITLE
Fix default browser refresh behaviour after POST request

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -97,8 +97,7 @@ export class Controller {
   startHistory() {
     this.location = Location.currentLocation
     this.restorationIdentifier = uuid()
-    this.history.start()
-    this.history.replace(this.location, this.restorationIdentifier)
+    this.history.start(this.location, this.restorationIdentifier)
   }
 
   stopHistory() {


### PR DESCRIPTION
Turbolinks initialisation currently breaks the default refresh behaviour when it's installed after a POST submission. A POST followed by a refresh should trigger an "Are you sure…?" confirm dialog, whereas with Turbolinks installed, it just reloads the existing location with a GET.

When starting up, [Turbolinks stores the initial location and restoration identifier in the session history](https://github.com/turbolinks/turbolinks/blob/b85b343f554371bea9aee4d2165b99a2b0522211/src/controller.ts#L101) by calling `replaceState`. This standardises the way to retrieve a restoration identifier on any popstate event. However, according the to the spec:

> 3. [If the state push flag is not set], update the current entry in browsingContext's session history so that … it represents a GET request, if it currently represents a non-GET request (e.g. it was the result of a POST submission).
> https://html.spec.whatwg.org/multipage/history.html#history-1

So when a page loads after a POST, Turbolinks replaces the current entry with a GET to the same location, and therefore will not re-POST or display a confirm dialog upon refresh\*.

This pull request tweaks initialisation to store the initial restoration identifier and location as properties on the `History` instance, avoiding the need to use `replaceState`. When the history is popped to the initial entry, `event.state` will be `null`, and by asserting that the existing location matches the stored initial location, the restoration identifier is retrieved accordingly. Pops to non-initial entries will be handled as before.

Fixes #229

---

\* This is observed in Chrome and Firefox, which comply with the spec. Safari behaves as we _want_, but does not comply with the spec.