### PR TITLE
Handle onPopState when turbolinks is disabled

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -43,13 +43,14 @@ export class History {
   // Event handlers
 
   onPopState = (event: PopStateEvent) => {
-    if (this.shouldHandlePopState()) {
-      const { turbolinks } = event.state
-      if (turbolinks) {
-        const location = Location.currentLocation
-        const { restorationIdentifier } = turbolinks
-        this.delegate.historyPoppedToLocationWithRestorationIdentifier(location, restorationIdentifier)
-      }
+    if (!this.shouldHandlePopState()) return
+    if (!event.state) return
+
+    const { turbolinks } = event.state
+    if (turbolinks) {
+      const location = Location.currentLocation
+      const { restorationIdentifier } = turbolinks
+      this.delegate.historyPoppedToLocationWithRestorationIdentifier(location, restorationIdentifier)
     }
   }
 

--- a/src/history.ts
+++ b/src/history.ts
@@ -47,11 +47,11 @@ export class History {
     if (!event.state) return
 
     const { turbolinks } = event.state
-    if (turbolinks) {
-      const location = Location.currentLocation
-      const { restorationIdentifier } = turbolinks
-      this.delegate.historyPoppedToLocationWithRestorationIdentifier(location, restorationIdentifier)
-    }
+    if (!turbolinks) return
+    
+    const location = Location.currentLocation
+    const { restorationIdentifier } = turbolinks
+    this.delegate.historyPoppedToLocationWithRestorationIdentifier(location, restorationIdentifier)
   }
 
   onPageLoad = (event: Event) => {


### PR DESCRIPTION
When clicking on a link where Turbolinks is disabled via the `data-turbolinks="false"` annotation the PopStateEvent would have no state. This would result in an `Cannot read property 'turbolinks' of null` error.
It is now handled by doing an early return in that situation.

If we were using TS version 3.7 we could've used optional chaining instead of early return guards.