### PR TITLE
New feature: data-turbolinks-permanent="shallow"

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,24 @@ You can avoid this problem by marking the counter element as permanent. Designat
 
 Before each render, Turbolinks matches all permanent elements by `id` and transfers them from the original page to the new page, preserving their data and event listeners.
 
+### Shallow Persistence
+
+Sometimes you want to maintain object identity across page loads, **but still have its content updated**.
+
+For example, consider a mobile sidebar that *slides in* upon clicking a button, and then *slides out* after clicking a navigation link. Clicking that link will load a new page, but under normal circumstances, turbolinks will **interrupt** your sidebar's slide out animation, since it **replaces** that element with a brand new one.
+
+On the other hand, you still want your navigation to be **updated by the server**. This is important for e.g. highlighting the active link, without needing to duplicate your logic in JavaScript.
+
+This is the use case for `data-turbolinks-permanent="shallow"`:
+
+```html
+<div id="sidebar-menu" data-turbolinks-permanent="shallow">
+  <% my_nav_links.each do |link| %>
+    ...
+  <% end %>
+</div>
+```
+
 # Advanced Usage
 
 ## Displaying Progress

--- a/src/tests/fixtures/permanent_element.html
+++ b/src/tests/fixtures/permanent_element.html
@@ -11,5 +11,6 @@
       <h1>Permanent element</h1>
     </section>
     <div id="permanent" data-turbolinks-permanent>Permanent element</div>
+    <div id="permanent-2" data-turbolinks-permanent="shallow" data-foo="two">Two</div>
   </body>
 </html>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -20,5 +20,6 @@
       <p><a id="permanent-element-link" href="/fixtures/permanent_element.html">Permanent element</a></p>
     </section>
     <div id="permanent" data-turbolinks-permanent>Rendering</div>
+    <div id="permanent-2" data-turbolinks-permanent="shallow" data-foo="one">One</div>
   </body>
 </html>

--- a/src/tests/rendering_tests.ts
+++ b/src/tests/rendering_tests.ts
@@ -124,6 +124,24 @@ export class RenderingTests extends TurbolinksTestCase {
     this.assert(await permanentElement.equals(await this.permanentElement))
   }
 
+  async "test preserves shallow permanent elements, updating their content"() {
+    let shallowPermanentElement = await this.shallowPermanentElement
+    this.assert.equal(await shallowPermanentElement.getVisibleText(), "One")
+    this.assert.equal(await shallowPermanentElement.getAttribute('data-foo'), "one")
+
+    this.clickSelector("#permanent-element-link")
+    await this.nextEventNamed("turbolinks:render")
+    this.assert(await shallowPermanentElement.equals(await this.shallowPermanentElement))
+    this.assert.equal(await shallowPermanentElement.getVisibleText(), "Two")
+    this.assert.equal(await shallowPermanentElement.getAttribute('data-foo'), "one")
+
+    this.goBack()
+    await this.nextEventNamed("turbolinks:render")
+    this.assert(await shallowPermanentElement.equals(await this.shallowPermanentElement))
+    this.assert.equal(await shallowPermanentElement.getVisibleText(), "One")
+    this.assert.equal(await shallowPermanentElement.getAttribute('data-foo'), "one")
+  }
+
   async "test before-cache event"() {
     this.beforeCache(body => body.innerHTML = "Modified")
     this.clickSelector("#same-origin-link")
@@ -163,6 +181,10 @@ export class RenderingTests extends TurbolinksTestCase {
 
   get permanentElement(): Promise<Element> {
     return this.querySelector("#permanent")
+  }
+
+  get shallowPermanentElement(): Promise<Element> {
+    return this.querySelector("#permanent-shallow")
   }
 
   get headScriptEvaluationCount(): Promise<number | undefined> {


### PR DESCRIPTION
This allows an element to maintain object identity but still have its contents updated by the server. Useful for animating layout elements.