### PR TITLE
Mention that jQuery's `on` will not see event.data

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,8 @@ Detects whether Turbolinks is supported in the current browser (see [Supported B
 
 ## Full List of Events
 
-Turbolinks emits events that allow you to track the navigation lifecycle and respond to page loading. Except where noted, Turbolinks fires events on the `document` object.
+Turbolinks emits events that allow you to track the navigation lifecycle and respond to page loading. Except where noted, Turbolinks fires events on the `document` object.  
+Note that `event.data` (when offered) is not available if you use jQuery's `$(document).on` method. Prefer `document.addEventListener`.
 
 * `turbolinks:click` fires when you click a Turbolinks-enabled link. The clicked element is the event target. Access the requested location with `event.data.url`. Cancel this event to let the click fall through to the browser as normal navigation.
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Detects whether Turbolinks is supported in the current browser (see [Supported B
 ## Full List of Events
 
 Turbolinks emits events that allow you to track the navigation lifecycle and respond to page loading. Except where noted, Turbolinks fires events on the `document` object.  
-Note that `event.data` (when offered) is not available if you use jQuery's `$(document).on` method. Prefer `document.addEventListener`.
+Note that when using jQuery, the data on the event must be accessed as `$event.originalEvent.data.url`.
 
 * `turbolinks:click` fires when you click a Turbolinks-enabled link. The clicked element is the event target. Access the requested location with `event.data.url`. Cancel this event to let the click fall through to the browser as normal navigation.
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Detects whether Turbolinks is supported in the current browser (see [Supported B
 ## Full List of Events
 
 Turbolinks emits events that allow you to track the navigation lifecycle and respond to page loading. Except where noted, Turbolinks fires events on the `document` object.  
-Note that when using jQuery, the data on the event must be accessed as `$event.originalEvent.data.url`.
+Note that when using jQuery, the data on the event must be accessed as `$event.originalEvent.data`.
 
 * `turbolinks:click` fires when you click a Turbolinks-enabled link. The clicked element is the event target. Access the requested location with `event.data.url`. Cancel this event to let the click fall through to the browser as normal navigation.
 


### PR DESCRIPTION
jQuery wraps events into a home-made event object. This wrapping makes the event.data unavailable. This commit adds a little mention of that fact to help a future developer save time and frustration.