### PR TITLE
Fix fire turbolinks:load event on very first page load

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -41,7 +41,11 @@ export class Controller {
   start() {
     if (Controller.supported && !this.started) {
       addEventListener("click", this.clickCaptured, true)
-      addEventListener("DOMContentLoaded", this.pageLoaded, false)
+      if (document.readyState !== "loading") {
+        this.pageLoaded();
+      } else {
+        addEventListener("DOMContentLoaded", this.pageLoaded, false)
+      }
       this.scrollManager.start()
       this.startHistory()
       this.started = true


### PR DESCRIPTION
This pull request fixes an issue where Turbolinks doesn't fire the `turbolinks:load` event when you call Turbolinks.start() after DOMContentLoaded is already triggered by the browser.

This usually happens when turbolinks is loaded with the async script flag.

Issue reproduction:
https://codepen.io/javan/pen/YqxYBK

Result:
![result](https://i.imgur.com/NMIIx91.png)

Expected:
![expected](https://cloud.githubusercontent.com/assets/5355/14142975/b7686d16-f656-11e5-9fa6-9a45a843dc99.png)