### PR TITLE
Fix CI by upgrading to Ubuntu from 14.04 to 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-sudo: false
+dist: xenial
 cache:
 - yarn
 before_script:


### PR DESCRIPTION
Potentially this fixes the build errors.

https://github.com/travis-ci/travis-ci/issues/9361
https://travis-ci.org/github/turbolinks/turbolinks/jobs/696558458#L448

If this works, we could theoretically also try an even more recent version, bionic, 18.04.



PS: Are there any plans for a stable 5.3 release? Friendly ping @javan, @sstephenson 