### PR TITLE
[WIP] Add turbolinks:before-unload event

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,8 @@ Note that when using jQuery, the data on the event must be accessed as `$event.o
 
 * `turbolinks:load` fires once after the initial page load, and again after every Turbolinks visit. Access visit timing metrics with the `event.data.timing` object.
 
+* `turbolinks:before-unload` fires for `onbeforeunload` and just before `before-render`. Use this method to destroy any persistent page specific JS.
+
 # Contributing to Turbolinks
 
 Turbolinks is open-source software, freely distributable under the terms of an [MIT-style license](LICENSE). The [source code is hosted on GitHub](https://github.com/turbolinks/turbolinks).

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -42,6 +42,9 @@ export class Controller {
     if (Controller.supported && !this.started) {
       addEventListener("click", this.clickCaptured, true)
       addEventListener("DOMContentLoaded", this.pageLoaded, false)
+      addEventListener("onbeforeunload", function(){
+        dispatch('turbolinks:before-unload')
+      });
       this.scrollManager.start()
       this.startHistory()
       this.started = true
@@ -250,6 +253,7 @@ export class Controller {
   }
 
   notifyApplicationBeforeRender(newBody: HTMLBodyElement) {
+    dispatch("turbolinks:before-unload")
     return dispatch("turbolinks:before-render", { data: { newBody }})
   }
 

--- a/src/tests/visit_tests.ts
+++ b/src/tests/visit_tests.ts
@@ -77,6 +77,37 @@ export class VisitTests extends TurbolinksTestCase {
       event.preventDefault()
     }, false))
   }
+
+  async "test before-unload event"() {
+    this.remote.execute(
+      () => addEventListener("turbolinks:before-unload", function eventListener(event) {
+        removeEventListener("turbolinks:before-unload", eventListener, false)
+        document.body.innerHTML = "Modified"
+      }, false)
+    );
+
+    await this.goToLocation("/fixtures/navigation.html")
+
+    this.assert.equal(document.body.innerHTML, "Modified")
+
+    this.remote.execute(
+      () => addEventListener("turbolinks:before-unload", function eventListener(event) {
+        removeEventListener("turbolinks:before-unload", eventListener, false)
+        document.body.innerHTML = "Modified2"
+      }, false)
+    );
+
+    this.remote.execute(
+      () => {
+        var event = document.createEvent("Events");
+        event.initEvent("onbeforeunload", true, false);
+        document.dispatchEvent(event);
+      }
+    );
+
+    this.assert.equal(document.body.innerHTML, "Modified2")
+  }
+
 }
 
 function contentTypeOfURL(url: string): Promise<string | undefined> {


### PR DESCRIPTION
Solves #146

Looking to see if there is any interest in adding the `turbolinks:before-unload` event or some variation of it.

Implementation based on https://github.com/turbolinks/turbolinks/issues/146#issuecomment-234680174

Marked as WIP because I have not verified the tests yet (my machine didn't run them and its late now)